### PR TITLE
ステップ4: エラーメッセージを改良

### DIFF
--- a/Sources/CCompiler/main.swift
+++ b/Sources/CCompiler/main.swift
@@ -21,8 +21,17 @@ struct CCompiler {
             } catch {
                 print("failed to write")
             }
+        } catch let error as CompileError {
+            switch error {
+            case .invalidSyntax(let index):
+                print(source)
+                print(String(repeating: " ", count: index) + "^不正な文法です")
+            case .invalidToken(let index):
+                print(source)
+                print(String(repeating: " ", count: index) + "^不正な文字です")
+            }
         } catch {
-            print("failed to compile")
+            print("不明なコンパイルエラー")
         }
     }
 }

--- a/Sources/Tokenizer/Token.swift
+++ b/Sources/Tokenizer/Token.swift
@@ -1,6 +1,8 @@
 public struct Token: Equatable {
     public var kind: TokenKind
     public var value: String
+
+    public var sourceIndex: Int
 }
 
 public enum TokenKind {

--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -1,5 +1,5 @@
 public enum TokenizeError: Error, Equatable {
-    case unknownToken
+    case unknownToken(index: Int)
 }
 
 public func tokenize(_ source: String) throws -> [Token] {
@@ -8,8 +8,10 @@ public func tokenize(_ source: String) throws -> [Token] {
     let charactors = [Character](source)
     var index = 0
 
-    func extractInt() -> String {
+    func extractNumber() -> Token {
         var token = ""
+        let startIndex = index
+
         while index < charactors.count {
             let nextToken = charactors[index]
             if nextToken.isNumber {
@@ -20,7 +22,7 @@ public func tokenize(_ source: String) throws -> [Token] {
             }
         }
 
-        return token
+        return Token(kind: .number, value: token, sourceIndex: startIndex)
     }
 
     while index < charactors.count {
@@ -30,24 +32,23 @@ public func tokenize(_ source: String) throws -> [Token] {
         }
 
         if charactors[index] == "+" {
-            tokens.append(Token(kind: .add, value: "+"))
+            tokens.append(Token(kind: .add, value: "+", sourceIndex: index))
             index += 1
             continue
         }
 
         if charactors[index] == "-" {
-            tokens.append(Token(kind: .sub, value: "-"))
+            tokens.append(Token(kind: .sub, value: "-", sourceIndex: index))
             index += 1
             continue
         }
 
         if charactors[index].isNumber {
-            let numberString = extractInt()
-            tokens.append(Token(kind: .number, value: numberString))
+            tokens.append(extractNumber())
             continue
         }
 
-        throw TokenizeError.unknownToken
+        throw TokenizeError.unknownToken(index: index)
     }
 
     return tokens

--- a/Tests/CCompilerCoreTest/CompileErrorTest.swift
+++ b/Tests/CCompilerCoreTest/CompileErrorTest.swift
@@ -3,11 +3,35 @@ import XCTest
 
 final class CompileErrorTest: XCTestCase {
 
-    func testExample1() throws {
+    func testInvalidSyntax1() throws {
         do {
             _ = try compile("5 ++")
         } catch let error as CompileError {
-            XCTAssertEqual(error, .invalidSyntax)
+            XCTAssertEqual(error, .invalidSyntax(index: 3))
+        }
+    }
+
+    func testInvalidSyntax2() throws {
+        do {
+            _ = try compile("")
+        } catch let error as CompileError {
+            XCTAssertEqual(error, .invalidSyntax(index: 0))
+        }
+    }
+
+    func testInvalidSyntax3() throws {
+        do {
+            _ = try compile("5 +")
+        } catch let error as CompileError {
+            XCTAssertEqual(error, .invalidSyntax(index: 3))
+        }
+    }
+
+    func testInvalidToken() throws {
+        do {
+            _ = try compile("5     ^")
+        } catch let error as CompileError {
+            XCTAssertEqual(error, .invalidToken(index: 6))
         }
     }
 }

--- a/Tests/TokenizerTest/TokenizerTest.swift
+++ b/Tests/TokenizerTest/TokenizerTest.swift
@@ -8,7 +8,7 @@ final class TokenizerTest: XCTestCase {
         XCTAssertEqual(
             tokens,
             [
-                Token(kind: .number, value: "5")
+                Token(kind: .number, value: "5", sourceIndex: 0)
             ]
         )
     }
@@ -18,7 +18,7 @@ final class TokenizerTest: XCTestCase {
         XCTAssertEqual(
             tokens,
             [
-                Token(kind: .number, value: "123")
+                Token(kind: .number, value: "123", sourceIndex: 0)
             ]
         )
     }
@@ -28,9 +28,9 @@ final class TokenizerTest: XCTestCase {
         XCTAssertEqual(
             tokens,
             [
-                Token(kind: .number, value: "1"),
-                Token(kind: .add, value: "+"),
-                Token(kind: .number, value: "23")
+                Token(kind: .number, value: "1", sourceIndex: 0),
+                Token(kind: .add, value: "+", sourceIndex: 2),
+                Token(kind: .number, value: "23", sourceIndex: 6)
             ]
         )
     }
@@ -39,7 +39,7 @@ final class TokenizerTest: XCTestCase {
         do {
             _ = try tokenize("1 ^")
         } catch let error as TokenizeError {
-            XCTAssertEqual(error, TokenizeError.unknownToken)
+            XCTAssertEqual(error, TokenizeError.unknownToken(index: 2))
         }
     }
 }


### PR DESCRIPTION
# 概要

https://www.sigbus.info/compilerbook#%E3%82%B9%E3%83%86%E3%83%83%E3%83%974%E3%82%A8%E3%83%A9%E3%83%BC%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8%E3%82%92%E6%94%B9%E8%89%AF

# 実装

- `TokenizeError`は内部実装のエラーなのでexec側には露出させず、CompileErrorがハブとなってエラーをラップすることに
- トークンからエラー場所を判別できるように`sourceindex`を追加
    - テストの記述がやや煩雑になりそうではあるのが懸念