### PR TITLE
Token構造をリファクタして予約語のトークナイズをCaseIteratbleで行う

### DIFF
--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -16,7 +16,7 @@ public func parse(tokens: [Token]) throws -> Node {
             throw ParseError.invalidSyntax(index: tokens.last.map { $0.sourceIndex + 1 } ?? 0)
         }
 
-        if case .number = tokens[index].kind {
+        if case .number = tokens[index] {
             let token = tokens[index]
             index += 1
             return token
@@ -26,12 +26,12 @@ public func parse(tokens: [Token]) throws -> Node {
     }
 
     @discardableResult
-    func consumeToken(_ tokenKind: Token.Kind.ReservedKind) throws -> Token {
+    func consumeReservedToken(_ reservedKind: Token.ReservedKind) throws -> Token {
         if index >= tokens.count {
             throw ParseError.invalidSyntax(index: tokens.last.map { $0.sourceIndex + 1 } ?? 0)
         }
 
-        if case .reserved(let reservedKind) = tokens[index].kind, reservedKind == tokenKind {
+        if case .reserved(let kind, _) = tokens[index], kind == reservedKind {
             let token = tokens[index]
             index += 1
             return token
@@ -50,15 +50,15 @@ public func parse(tokens: [Token]) throws -> Node {
         var node = try relational()
 
         while index < tokens.count {
-            switch tokens[index].kind {
-            case .reserved(kind: .equal):
-                let token = try consumeToken(.equal)
+            switch tokens[index] {
+            case .reserved(.equal, _):
+                let token = try consumeReservedToken(.equal)
                 let rightNode = try relational()
 
                 node = Node(kind: .equal, left: node, right: rightNode, token: token)
 
-            case .reserved(kind: .notEqual):
-                let token = try consumeToken(.notEqual)
+            case .reserved(.notEqual, _):
+                let token = try consumeReservedToken(.notEqual)
                 let rightNode = try relational()
 
                 node = Node(kind: .notEqual, left: node, right: rightNode, token: token)
@@ -76,27 +76,27 @@ public func parse(tokens: [Token]) throws -> Node {
         var node = try add()
 
         while index < tokens.count {
-            switch tokens[index].kind {
-            case .reserved(kind: .lessThan):
-                let token = try consumeToken(.lessThan)
+            switch tokens[index] {
+            case .reserved(.lessThan, _):
+                let token = try consumeReservedToken(.lessThan)
                 let rightNode = try add()
 
                 node = Node(kind: .lessThan, left: node, right: rightNode, token: token)
 
-            case .reserved(kind: .lessThanOrEqual):
-                let token = try consumeToken(.lessThanOrEqual)
+            case .reserved(.lessThanOrEqual, _):
+                let token = try consumeReservedToken(.lessThanOrEqual)
                 let rightNode = try add()
 
                 node = Node(kind: .lessThanOrEqual, left: node, right: rightNode, token: token)
 
-            case .reserved(kind: .greaterThan):
-                let token = try consumeToken(.greaterThan)
+            case .reserved(.greaterThan, _):
+                let token = try consumeReservedToken(.greaterThan)
                 let rightNode = try add()
 
                 node = Node(kind: .lessThan, left: rightNode, right: node, token: token)
 
-            case .reserved(kind: .greaterThanOrEqual):
-                let token = try consumeToken(.greaterThanOrEqual)
+            case .reserved(.greaterThanOrEqual, _):
+                let token = try consumeReservedToken(.greaterThanOrEqual)
                 let rightNode = try add()
 
                 node = Node(kind: .lessThanOrEqual, left: rightNode, right: node, token: token)
@@ -114,15 +114,15 @@ public func parse(tokens: [Token]) throws -> Node {
         var node = try mul()
 
         while index < tokens.count {
-            switch tokens[index].kind {
-            case .reserved(kind: .add):
-                let addToken = try consumeToken(.add)
+            switch tokens[index] {
+            case .reserved(.add, _):
+                let addToken = try consumeReservedToken(.add)
                 let rightNode = try mul()
 
                 node = Node(kind: .add, left: node, right: rightNode, token: addToken)
 
-            case .reserved(kind: .sub):
-                let subToken = try consumeToken(.sub)
+            case .reserved(.sub, _):
+                let subToken = try consumeReservedToken(.sub)
                 let rightNode = try mul()
 
                 node = Node(kind: .sub, left: node, right: rightNode, token: subToken)
@@ -140,15 +140,15 @@ public func parse(tokens: [Token]) throws -> Node {
         var node = try unary()
 
         while index < tokens.count {
-            switch tokens[index].kind {
-            case .reserved(kind: .mul):
-                let mulToken = try consumeToken(.mul)
+            switch tokens[index] {
+            case .reserved(.mul, _):
+                let mulToken = try consumeReservedToken(.mul)
                 let rightNode = try unary()
 
                 node = Node(kind: .mul, left: node, right: rightNode, token: mulToken)
 
-            case .reserved(kind: .div):
-                let divToken = try consumeToken(.div)
+            case .reserved(.div, _):
+                let divToken = try consumeReservedToken(.div)
                 let rightNode = try unary()
 
                 node = Node(kind: .div, left: node, right: rightNode, token: divToken)
@@ -167,18 +167,18 @@ public func parse(tokens: [Token]) throws -> Node {
             throw ParseError.invalidSyntax(index: tokens.last.map { $0.sourceIndex + 1 } ?? 0)
         }
 
-        switch tokens[index].kind {
-        case .reserved(kind: .add):
-            try consumeToken(.add)
+        switch tokens[index] {
+        case .reserved(.add, _):
+            try consumeReservedToken(.add)
 
             // 単項+は影響がないので無視する
             return try primary()
 
-        case .reserved(kind: .sub):
-            let subToken = try consumeToken(.sub)
+        case .reserved(.sub, _):
+            let subToken = try consumeReservedToken(.sub)
 
             // 0 - rightとして認識
-            let left = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("0"), sourceIndex: tokens[index].sourceIndex))
+            let left = Node(kind: .number, left: nil, right: nil, token: .number("0", sourceIndex: tokens[index].sourceIndex))
             let right = try primary()
 
             return Node(kind: .sub, left: left, right: right, token: subToken)
@@ -194,13 +194,13 @@ public func parse(tokens: [Token]) throws -> Node {
             throw ParseError.invalidSyntax(index: tokens.last.map { $0.sourceIndex + 1 } ?? 0)
         }
 
-        switch tokens[index].kind {
-        case .reserved(kind: .parenthesisLeft):
-            try consumeToken(.parenthesisLeft)
+        switch tokens[index] {
+        case .reserved(.parenthesisLeft, _):
+            try consumeReservedToken(.parenthesisLeft)
 
             let exprNode = try expr()
 
-            try consumeToken(.parenthesisRight)
+            try consumeReservedToken(.parenthesisRight)
 
             return exprNode
 

--- a/Sources/Tokenizer/Token.swift
+++ b/Sources/Tokenizer/Token.swift
@@ -1,68 +1,65 @@
-public struct Token: Equatable {
+public enum Token: Equatable {
 
     // MARK: - Property
 
-    public var kind: Kind
-    public var sourceIndex: Int
+    case reserved(_ kind: ReservedKind, sourceIndex: Int)
+    case number(_ value: String, sourceIndex: Int)
 
     public var value: String {
-        switch kind {
-        case .reserved(let kind):
+        switch self {
+        case .reserved(let kind, _):
             return kind.rawValue
 
-        case .number(let value):
+        case .number(let value, _):
             return value
         }
     }
 
-    // MARK: - Initializer
+    public var sourceIndex: Int {
+        switch self {
+        case .reserved(_, let sourceIndex):
+            return sourceIndex
 
-    public init(kind: Kind, sourceIndex: Int) {
-        self.kind = kind
-        self.sourceIndex = sourceIndex
+        case .number(_, let sourceIndex):
+            return sourceIndex
+        }
     }
 
-    public enum Kind: Equatable {
+    public enum ReservedKind: String, CaseIterable {
+        /// `+`
+        case add = "+"
 
-        case reserved(ReservedKind)
-        case number(String)
+        /// `-`
+        case sub = "-"
 
-        public enum ReservedKind: String, CaseIterable {
-            /// `+`
-            case add = "+"
+        /// `*`
+        case mul = "*"
 
-            /// `-`
-            case sub = "-"
+        /// `/`
+        case div = "/"
 
-            /// `*`
-            case mul = "*"
+        /// `(`
+        case parenthesisLeft = "("
 
-            /// `/`
-            case div = "/"
+        /// `)`
+        case parenthesisRight = ")"
 
-            /// `(`
-            case parenthesisLeft = "("
+        /// `==`
+        case equal = "=="
 
-            /// `)`
-            case parenthesisRight = ")"
+        /// `!=`
+        case notEqual = "!="
 
-            /// `==`
-            case equal = "=="
+        /// `<`
+        case lessThan = "<"
 
-            /// `!=`
-            case notEqual = "!="
+        /// `<=`
+        case lessThanOrEqual = "<="
 
-            /// `<`
-            case lessThan = "<"
+        /// `>`
+        case greaterThan = ">"
 
-            /// `<=`
-            case lessThanOrEqual = "<="
-
-            /// `>`
-            case greaterThan = ">"
-
-            /// `>=`
-            case greaterThanOrEqual = ">="
-        }
+        /// `>=`
+        case greaterThanOrEqual = ">="
     }
 }

--- a/Sources/Tokenizer/Token.swift
+++ b/Sources/Tokenizer/Token.swift
@@ -1,58 +1,68 @@
 public struct Token: Equatable {
 
     // MARK: - Property
-    
-    public var kind: TokenKind
-    public var value: String
 
+    public var kind: Kind
     public var sourceIndex: Int
+
+    public var value: String {
+        switch kind {
+        case .reserved(let kind):
+            return kind.rawValue
+
+        case .number(let value):
+            return value
+        }
+    }
 
     // MARK: - Initializer
 
-    public init(kind: TokenKind, value: String, sourceIndex: Int) {
+    public init(kind: Kind, sourceIndex: Int) {
         self.kind = kind
-        self.value = value
         self.sourceIndex = sourceIndex
     }
-}
 
-public enum TokenKind {
-    /// `+`
-    case add
+    public enum Kind: Equatable {
 
-    /// `-`
-    case sub
+        case reserved(ReservedKind)
+        case number(String)
 
-    /// `*`
-    case mul
+        public enum ReservedKind: String, CaseIterable {
+            /// `+`
+            case add = "+"
 
-    /// `/`
-    case div
+            /// `-`
+            case sub = "-"
 
-    /// integer e.g. 1, 123
-    case number
+            /// `*`
+            case mul = "*"
 
-    /// `(`
-    case parenthesisLeft
+            /// `/`
+            case div = "/"
 
-    /// `)`
-    case parenthesisRight
+            /// `(`
+            case parenthesisLeft = "("
 
-    /// `==`
-    case equal
+            /// `)`
+            case parenthesisRight = ")"
 
-    /// `!=`
-    case notEqual
+            /// `==`
+            case equal = "=="
 
-    /// `<`
-    case lessThan
+            /// `!=`
+            case notEqual = "!="
 
-    /// `<=`
-    case lessThanOrEqual
+            /// `<`
+            case lessThan = "<"
 
-    /// `>`
-    case greaterThan
+            /// `<=`
+            case lessThanOrEqual = "<="
 
-    /// `>=`
-    case greaterThanOrEqual
+            /// `>`
+            case greaterThan = ">"
+
+            /// `>=`
+            case greaterThanOrEqual = ">="
+        }
+    }
 }

--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -22,12 +22,12 @@ public func tokenize(source: String) throws -> [Token] {
             }
         }
 
-        return Token(kind: .number(string), sourceIndex: startIndex)
+        return .number(string, sourceIndex: startIndex)
     }
 
     // 文字数が多い物からチェックしないといけない
     // 例: <= の時に<を先にチェックすると<, =の2つのトークンになってしまう
-    let reservedKinds = Token.Kind.ReservedKind.allCases.sorted { $0.rawValue.count > $1.rawValue.count }
+    let reservedKinds = Token.ReservedKind.allCases.sorted { $0.rawValue.count > $1.rawValue.count }
 
 root:
     while index < charactors.count {
@@ -45,7 +45,7 @@ root:
             let reservedString = reservedKind.rawValue
             if index + (reservedString.count - 1) < charactors.count,
                String(charactors[index..<index+reservedString.count]) == reservedString {
-                tokens.append(Token(kind: .reserved(reservedKind), sourceIndex: index))
+                tokens.append(.reserved(reservedKind, sourceIndex: index))
                 index += reservedString.count
 
                 continue root

--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -9,96 +9,29 @@ public func tokenize(source: String) throws -> [Token] {
     var index = 0
 
     func extractNumber() -> Token {
-        var token = ""
+        var string = ""
         let startIndex = index
 
         while index < charactors.count {
             let nextToken = charactors[index]
             if nextToken.isNumber {
-                token += String(nextToken)
+                string += String(nextToken)
                 index += 1
             } else {
                 break
             }
         }
 
-        return Token(kind: .number, value: token, sourceIndex: startIndex)
+        return Token(kind: .number(string), sourceIndex: startIndex)
     }
 
+    // 文字数が多い物からチェックしないといけない
+    // 例: <= の時に<を先にチェックすると<, =の2つのトークンになってしまう
+    let reservedKinds = Token.Kind.ReservedKind.allCases.sorted { $0.rawValue.count > $1.rawValue.count }
+
+root:
     while index < charactors.count {
         if charactors[index].isWhitespace {
-            index += 1
-            continue
-        }
-
-        if charactors[index] == "+" {
-            tokens.append(Token(kind: .add, value: "+", sourceIndex: index))
-            index += 1
-            continue
-        }
-
-        if charactors[index] == "-" {
-            tokens.append(Token(kind: .sub, value: "-", sourceIndex: index))
-            index += 1
-            continue
-        }
-
-        if charactors[index] == "*" {
-            tokens.append(Token(kind: .mul, value: "*", sourceIndex: index))
-            index += 1
-            continue
-        }
-
-        if charactors[index] == "/" {
-            tokens.append(Token(kind: .div, value: "/", sourceIndex: index))
-            index += 1
-            continue
-        }
-
-        if charactors[index] == "(" {
-            tokens.append(Token(kind: .parenthesisLeft, value: "(", sourceIndex: index))
-            index += 1
-            continue
-        }
-
-        if charactors[index] == ")" {
-            tokens.append(Token(kind: .parenthesisRight, value: ")", sourceIndex: index))
-            index += 1
-            continue
-        }
-
-        if index + 1 < charactors.count, String(charactors[index...index+1]) == "==" {
-            tokens.append(Token(kind: .equal, value: "==", sourceIndex: index))
-            index += 2
-            continue
-        }
-
-        if index + 1 < charactors.count, String(charactors[index...index+1]) == "!=" {
-            tokens.append(Token(kind: .notEqual, value: "!=", sourceIndex: index))
-            index += 2
-            continue
-        }
-
-        if index + 1 < charactors.count, String(charactors[index...index+1]) == "<=" {
-            tokens.append(Token(kind: .lessThanOrEqual, value: "<=", sourceIndex: index))
-            index += 2
-            continue
-        }
-
-        if index + 1 < charactors.count, String(charactors[index...index+1]) == ">=" {
-            tokens.append(Token(kind: .greaterThanOrEqual, value: ">=", sourceIndex: index))
-            index += 2
-            continue
-        }
-
-        if charactors[index] == "<" {
-            tokens.append(Token(kind: .lessThan, value: "<", sourceIndex: index))
-            index += 1
-            continue
-        }
-
-        if charactors[index] == ">" {
-            tokens.append(Token(kind: .greaterThan, value: ">", sourceIndex: index))
             index += 1
             continue
         }
@@ -106,6 +39,17 @@ public func tokenize(source: String) throws -> [Token] {
         if charactors[index].isNumber {
             tokens.append(extractNumber())
             continue
+        }
+
+        for reservedKind in reservedKinds {
+            let reservedString = reservedKind.rawValue
+            if index + (reservedString.count - 1) < charactors.count,
+               String(charactors[index..<index+reservedString.count]) == reservedString {
+                tokens.append(Token(kind: .reserved(reservedKind), sourceIndex: index))
+                index += reservedString.count
+
+                continue root
+            }
         }
 
         throw TokenizeError.unknownToken(index: index)

--- a/Tests/ParserTest/ParserTest.swift
+++ b/Tests/ParserTest/ParserTest.swift
@@ -5,23 +5,23 @@ import Tokenizer
 final class ParserTest: XCTestCase {
 
     func testNumber() throws {
-        let node = try parse(tokens: [Token(kind: .number("5"), sourceIndex: 0)])
+        let node = try parse(tokens: [.number("5", sourceIndex: 0)])
         XCTAssertEqual(
             node,
-            Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("5"), sourceIndex: 0))
+            Node(kind: .number, left: nil, right: nil, token: .number("5", sourceIndex: 0))
         )
     }
 
     func testAdd() throws {
         let node = try parse(tokens: [
-            Token(kind: .number("1"), sourceIndex: 0),
-            Token(kind: .reserved(.add), sourceIndex: 1),
-            Token(kind: .number("2"), sourceIndex: 2)
+            .number("1", sourceIndex: 0),
+            .reserved(.add, sourceIndex: 1),
+            .number("2", sourceIndex: 2)
         ])
 
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 2))
-        let rootNode = Node(kind: .add, left: leftNode, right: rightNode, token: Token(kind: .reserved(.add), sourceIndex: 1))
+        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
+        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
+        let rootNode = Node(kind: .add, left: leftNode, right: rightNode, token: .reserved(.add, sourceIndex: 1))
 
         XCTAssertEqual(
             node,
@@ -31,19 +31,19 @@ final class ParserTest: XCTestCase {
 
     func testAdd3() throws {
         let node = try parse(tokens: [
-            Token(kind: .number("1"), sourceIndex: 0),
-            Token(kind: .reserved(.add), sourceIndex: 1),
-            Token(kind: .number("2"), sourceIndex: 2),
-            Token(kind: .reserved(.add), sourceIndex: 3),
-            Token(kind: .number("3"), sourceIndex: 4),
+            .number("1", sourceIndex: 0),
+            .reserved(.add, sourceIndex: 1),
+            .number("2", sourceIndex: 2),
+            .reserved(.add, sourceIndex: 3),
+            .number("3", sourceIndex: 4),
         ])
 
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 2))
-        let addNode = Node(kind: .add, left: leftNode, right: rightNode, token: Token(kind: .reserved(.add), sourceIndex: 1))
+        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
+        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
+        let addNode = Node(kind: .add, left: leftNode, right: rightNode, token: .reserved(.add, sourceIndex: 1))
 
-        let rightNode2 = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("3"), sourceIndex: 4))
-        let rootNode = Node(kind: .add, left: addNode, right: rightNode2, token: Token(kind: .reserved(.add), sourceIndex: 3))
+        let rightNode2 = Node(kind: .number, left: nil, right: nil, token: .number("3", sourceIndex: 4))
+        let rootNode = Node(kind: .add, left: addNode, right: rightNode2, token: .reserved(.add, sourceIndex: 3))
 
         XCTAssertEqual(
             node,
@@ -53,21 +53,21 @@ final class ParserTest: XCTestCase {
 
     func testMul() throws {
         let node = try parse(tokens: [
-            Token(kind: .number("1"), sourceIndex: 0),
-            Token(kind: .reserved(.mul), sourceIndex: 1),
-            Token(kind: .reserved(.parenthesisLeft), sourceIndex: 2),
-            Token(kind: .number("2"), sourceIndex: 3),
-            Token(kind: .reserved(.add), sourceIndex: 4),
-            Token(kind: .number("3"), sourceIndex: 5),
-            Token(kind: .reserved(.parenthesisRight), sourceIndex: 6),
+            .number("1", sourceIndex: 0),
+            .reserved(.mul, sourceIndex: 1),
+            .reserved(.parenthesisLeft, sourceIndex: 2),
+            .number("2", sourceIndex: 3),
+            .reserved(.add, sourceIndex: 4),
+            .number("3", sourceIndex: 5),
+            .reserved(.parenthesisRight, sourceIndex: 6),
         ])
 
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 3))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("3"), sourceIndex: 5))
-        let addNode = Node(kind: .add, left: leftNode, right: rightNode, token: Token(kind: .reserved(.add), sourceIndex: 4))
+        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 3))
+        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("3", sourceIndex: 5))
+        let addNode = Node(kind: .add, left: leftNode, right: rightNode, token: .reserved(.add, sourceIndex: 4))
 
-        let mulLeftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
-        let rootNode = Node(kind: .mul, left: mulLeftNode, right: addNode, token: Token(kind: .reserved(.mul), sourceIndex: 1))
+        let mulLeftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
+        let rootNode = Node(kind: .mul, left: mulLeftNode, right: addNode, token: .reserved(.mul, sourceIndex: 1))
 
         XCTAssertEqual(
             node,
@@ -77,11 +77,11 @@ final class ParserTest: XCTestCase {
 
     func testUnaryAdd() throws {
         let node = try parse(tokens: [
-            Token(kind: .reserved(.add), sourceIndex: 0),
-            Token(kind: .number("1"), sourceIndex: 1)
+            .reserved(.add, sourceIndex: 0),
+            .number("1", sourceIndex: 1)
         ])
 
-        let numberNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 1))
+        let numberNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 1))
 
         XCTAssertEqual(
             node,
@@ -91,13 +91,13 @@ final class ParserTest: XCTestCase {
 
     func testUnarySub() throws {
         let node = try parse(tokens: [
-            Token(kind: .reserved(.sub), sourceIndex: 0),
-            Token(kind: .number("1"), sourceIndex: 1)
+            .reserved(.sub, sourceIndex: 0),
+            .number("1", sourceIndex: 1)
         ])
 
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("0"), sourceIndex: 1))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 1))
-        let rootNode = Node(kind: .sub, left: leftNode, right: rightNode, token: Token(kind: .reserved(.sub), sourceIndex: 0))
+        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("0", sourceIndex: 1))
+        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 1))
+        let rootNode = Node(kind: .sub, left: leftNode, right: rightNode, token: .reserved(.sub, sourceIndex: 0))
 
         XCTAssertEqual(
             node,
@@ -108,14 +108,14 @@ final class ParserTest: XCTestCase {
     func testCompare() throws {
         try XCTContext.runActivity(named: "equal") { _ in
             let node = try parse(tokens: [
-                Token(kind: .number("1"), sourceIndex: 0),
-                Token(kind: .reserved(.equal), sourceIndex: 1),
-                Token(kind: .number("2"), sourceIndex: 3)
+                .number("1", sourceIndex: 0),
+                .reserved(.equal, sourceIndex: 1),
+                .number("2", sourceIndex: 3)
             ])
 
-            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
-            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 3))
-            let rootNode = Node(kind: .equal, left: leftNode, right: rightNode, token: Token(kind: .reserved(.equal), sourceIndex: 1))
+            let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
+            let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 3))
+            let rootNode = Node(kind: .equal, left: leftNode, right: rightNode, token: .reserved(.equal, sourceIndex: 1))
 
             XCTAssertEqual(
                 node,
@@ -125,14 +125,14 @@ final class ParserTest: XCTestCase {
 
         try XCTContext.runActivity(named: "notEqual") { _ in
             let node = try parse(tokens: [
-                Token(kind: .number("1"), sourceIndex: 0),
-                Token(kind: .reserved(.notEqual), sourceIndex: 1),
-                Token(kind: .number("2"), sourceIndex: 3)
+                .number("1", sourceIndex: 0),
+                .reserved(.notEqual, sourceIndex: 1),
+                .number("2", sourceIndex: 3)
             ])
 
-            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
-            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 3))
-            let rootNode = Node(kind: .notEqual, left: leftNode, right: rightNode, token: Token(kind: .reserved(.notEqual), sourceIndex: 1))
+            let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
+            let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 3))
+            let rootNode = Node(kind: .notEqual, left: leftNode, right: rightNode, token: .reserved(.notEqual, sourceIndex: 1))
 
             XCTAssertEqual(
                 node,
@@ -142,14 +142,14 @@ final class ParserTest: XCTestCase {
 
         try XCTContext.runActivity(named: "greaterThan") { _ in
             let node = try parse(tokens: [
-                Token(kind: .number("1"), sourceIndex: 0),
-                Token(kind: .reserved(.greaterThan), sourceIndex: 1),
-                Token(kind: .number("2"), sourceIndex: 2)
+                .number("1", sourceIndex: 0),
+                .reserved(.greaterThan, sourceIndex: 1),
+                .number("2", sourceIndex: 2)
             ])
 
-            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
-            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 2))
-            let rootNode = Node(kind: .lessThan, left: rightNode, right: leftNode, token: Token(kind: .reserved(.greaterThan), sourceIndex: 1))
+            let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
+            let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
+            let rootNode = Node(kind: .lessThan, left: rightNode, right: leftNode, token: .reserved(.greaterThan, sourceIndex: 1))
 
             XCTAssertEqual(
                 node,
@@ -159,14 +159,14 @@ final class ParserTest: XCTestCase {
 
         try XCTContext.runActivity(named: "greaterThanOrEqual") { _ in
             let node = try parse(tokens: [
-                Token(kind: .number("1"), sourceIndex: 0),
-                Token(kind: .reserved(.greaterThanOrEqual), sourceIndex: 1),
-                Token(kind: .number("2"), sourceIndex: 3)
+                .number("1", sourceIndex: 0),
+                .reserved(.greaterThanOrEqual, sourceIndex: 1),
+                .number("2", sourceIndex: 3)
             ])
 
-            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
-            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 3))
-            let rootNode = Node(kind: .lessThanOrEqual, left: rightNode, right: leftNode, token: Token(kind: .reserved(.greaterThanOrEqual), sourceIndex: 1))
+            let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
+            let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 3))
+            let rootNode = Node(kind: .lessThanOrEqual, left: rightNode, right: leftNode, token: .reserved(.greaterThanOrEqual, sourceIndex: 1))
 
             XCTAssertEqual(
                 node,
@@ -176,14 +176,14 @@ final class ParserTest: XCTestCase {
 
         try XCTContext.runActivity(named: "lessThan") { _ in
             let node = try parse(tokens: [
-                Token(kind: .number("1"), sourceIndex: 0),
-                Token(kind: .reserved(.lessThan), sourceIndex: 1),
-                Token(kind: .number("2"), sourceIndex: 2)
+                .number("1", sourceIndex: 0),
+                .reserved(.lessThan, sourceIndex: 1),
+                .number("2", sourceIndex: 2)
             ])
 
-            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
-            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 2))
-            let rootNode = Node(kind: .lessThan, left: leftNode, right: rightNode, token: Token(kind: .reserved(.lessThan), sourceIndex: 1))
+            let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
+            let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
+            let rootNode = Node(kind: .lessThan, left: leftNode, right: rightNode, token: .reserved(.lessThan, sourceIndex: 1))
 
             XCTAssertEqual(
                 node,
@@ -193,14 +193,14 @@ final class ParserTest: XCTestCase {
 
         try XCTContext.runActivity(named: "lessThanOrEqual") { _ in
             let node = try parse(tokens: [
-                Token(kind: .number("1"), sourceIndex: 0),
-                Token(kind: .reserved(.lessThanOrEqual), sourceIndex: 1),
-                Token(kind: .number("2"), sourceIndex: 3)
+                .number("1", sourceIndex: 0),
+                .reserved(.lessThanOrEqual, sourceIndex: 1),
+                .number("2", sourceIndex: 3)
             ])
 
-            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
-            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 3))
-            let rootNode = Node(kind: .lessThanOrEqual, left: leftNode, right: rightNode, token: Token(kind: .reserved(.lessThanOrEqual), sourceIndex: 1))
+            let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
+            let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 3))
+            let rootNode = Node(kind: .lessThanOrEqual, left: leftNode, right: rightNode, token: .reserved(.lessThanOrEqual, sourceIndex: 1))
 
             XCTAssertEqual(
                 node,

--- a/Tests/ParserTest/ParserTest.swift
+++ b/Tests/ParserTest/ParserTest.swift
@@ -5,23 +5,23 @@ import Tokenizer
 final class ParserTest: XCTestCase {
 
     func testNumber() throws {
-        let node = try parse(tokens: [Token(kind: .number, value: "5", sourceIndex: 0)])
+        let node = try parse(tokens: [Token(kind: .number("5"), sourceIndex: 0)])
         XCTAssertEqual(
             node,
-            Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "5", sourceIndex: 0))
+            Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("5"), sourceIndex: 0))
         )
     }
 
     func testAdd() throws {
         let node = try parse(tokens: [
-            Token(kind: .number, value: "1", sourceIndex: 0),
-            Token(kind: .add, value: "+", sourceIndex: 1),
-            Token(kind: .number, value: "2", sourceIndex: 2)
+            Token(kind: .number("1"), sourceIndex: 0),
+            Token(kind: .reserved(.add), sourceIndex: 1),
+            Token(kind: .number("2"), sourceIndex: 2)
         ])
 
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "2", sourceIndex: 2))
-        let rootNode = Node(kind: .add, left: leftNode, right: rightNode, token: Token(kind: .add, value: "+", sourceIndex: 1))
+        let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
+        let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 2))
+        let rootNode = Node(kind: .add, left: leftNode, right: rightNode, token: Token(kind: .reserved(.add), sourceIndex: 1))
 
         XCTAssertEqual(
             node,
@@ -31,19 +31,19 @@ final class ParserTest: XCTestCase {
 
     func testAdd3() throws {
         let node = try parse(tokens: [
-            Token(kind: .number, value: "1", sourceIndex: 0),
-            Token(kind: .add, value: "+", sourceIndex: 1),
-            Token(kind: .number, value: "2", sourceIndex: 2),
-            Token(kind: .add, value: "+", sourceIndex: 3),
-            Token(kind: .number, value: "3", sourceIndex: 4)
+            Token(kind: .number("1"), sourceIndex: 0),
+            Token(kind: .reserved(.add), sourceIndex: 1),
+            Token(kind: .number("2"), sourceIndex: 2),
+            Token(kind: .reserved(.add), sourceIndex: 3),
+            Token(kind: .number("3"), sourceIndex: 4),
         ])
 
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "2", sourceIndex: 2))
-        let addNode = Node(kind: .add, left: leftNode, right: rightNode, token: Token(kind: .add, value: "+", sourceIndex: 1))
+        let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
+        let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 2))
+        let addNode = Node(kind: .add, left: leftNode, right: rightNode, token: Token(kind: .reserved(.add), sourceIndex: 1))
 
-        let rightNode2 = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "3", sourceIndex: 4))
-        let rootNode = Node(kind: .add, left: addNode, right: rightNode2, token: Token(kind: .add, value: "+", sourceIndex: 3))
+        let rightNode2 = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("3"), sourceIndex: 4))
+        let rootNode = Node(kind: .add, left: addNode, right: rightNode2, token: Token(kind: .reserved(.add), sourceIndex: 3))
 
         XCTAssertEqual(
             node,
@@ -53,21 +53,21 @@ final class ParserTest: XCTestCase {
 
     func testMul() throws {
         let node = try parse(tokens: [
-            Token(kind: .number, value: "1", sourceIndex: 0),
-            Token(kind: .mul, value: "*", sourceIndex: 1),
-            Token(kind: .parenthesisLeft, value: "(", sourceIndex: 2),
-            Token(kind: .number, value: "2", sourceIndex: 3),
-            Token(kind: .add, value: "+", sourceIndex: 4),
-            Token(kind: .number, value: "3", sourceIndex: 5),
-            Token(kind: .parenthesisRight, value: ")", sourceIndex: 6),
+            Token(kind: .number("1"), sourceIndex: 0),
+            Token(kind: .reserved(.mul), sourceIndex: 1),
+            Token(kind: .reserved(.parenthesisLeft), sourceIndex: 2),
+            Token(kind: .number("2"), sourceIndex: 3),
+            Token(kind: .reserved(.add), sourceIndex: 4),
+            Token(kind: .number("3"), sourceIndex: 5),
+            Token(kind: .reserved(.parenthesisRight), sourceIndex: 6),
         ])
 
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "2", sourceIndex: 3))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "3", sourceIndex: 5))
-        let addNode = Node(kind: .add, left: leftNode, right: rightNode, token: Token(kind: .add, value: "+", sourceIndex: 4))
+        let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 3))
+        let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("3"), sourceIndex: 5))
+        let addNode = Node(kind: .add, left: leftNode, right: rightNode, token: Token(kind: .reserved(.add), sourceIndex: 4))
 
-        let mulLeftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "1", sourceIndex: 0))
-        let rootNode = Node(kind: .mul, left: mulLeftNode, right: addNode, token: Token(kind: .mul, value: "*", sourceIndex: 1))
+        let mulLeftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
+        let rootNode = Node(kind: .mul, left: mulLeftNode, right: addNode, token: Token(kind: .reserved(.mul), sourceIndex: 1))
 
         XCTAssertEqual(
             node,
@@ -77,11 +77,11 @@ final class ParserTest: XCTestCase {
 
     func testUnaryAdd() throws {
         let node = try parse(tokens: [
-            Token(kind: .add, value: "+", sourceIndex: 0),
-            Token(kind: .number, value: "1", sourceIndex: 1),
+            Token(kind: .reserved(.add), sourceIndex: 0),
+            Token(kind: .number("1"), sourceIndex: 1)
         ])
 
-        let numberNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "1", sourceIndex: 1))
+        let numberNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 1))
 
         XCTAssertEqual(
             node,
@@ -91,13 +91,13 @@ final class ParserTest: XCTestCase {
 
     func testUnarySub() throws {
         let node = try parse(tokens: [
-            Token(kind: .sub, value: "-", sourceIndex: 0),
-            Token(kind: .number, value: "1", sourceIndex: 1),
+            Token(kind: .reserved(.sub), sourceIndex: 0),
+            Token(kind: .number("1"), sourceIndex: 1)
         ])
 
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "0", sourceIndex: 1))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "1", sourceIndex: 1))
-        let rootNode = Node(kind: .sub, left: leftNode, right: rightNode, token: Token(kind: .sub, value: "-", sourceIndex: 0))
+        let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("0"), sourceIndex: 1))
+        let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 1))
+        let rootNode = Node(kind: .sub, left: leftNode, right: rightNode, token: Token(kind: .reserved(.sub), sourceIndex: 0))
 
         XCTAssertEqual(
             node,
@@ -108,14 +108,14 @@ final class ParserTest: XCTestCase {
     func testCompare() throws {
         try XCTContext.runActivity(named: "equal") { _ in
             let node = try parse(tokens: [
-                Token(kind: .number, value: "1", sourceIndex: 0),
-                Token(kind: .equal, value: "==", sourceIndex: 1),
-                Token(kind: .number, value: "2", sourceIndex: 3),
+                Token(kind: .number("1"), sourceIndex: 0),
+                Token(kind: .reserved(.equal), sourceIndex: 1),
+                Token(kind: .number("2"), sourceIndex: 3)
             ])
 
-            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "1", sourceIndex: 0))
-            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "2", sourceIndex: 3))
-            let rootNode = Node(kind: .equal, left: leftNode, right: rightNode, token: Token(kind: .equal, value: "==", sourceIndex: 1))
+            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
+            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 3))
+            let rootNode = Node(kind: .equal, left: leftNode, right: rightNode, token: Token(kind: .reserved(.equal), sourceIndex: 1))
 
             XCTAssertEqual(
                 node,
@@ -125,14 +125,14 @@ final class ParserTest: XCTestCase {
 
         try XCTContext.runActivity(named: "notEqual") { _ in
             let node = try parse(tokens: [
-                Token(kind: .number, value: "1", sourceIndex: 0),
-                Token(kind: .notEqual, value: "!=", sourceIndex: 1),
-                Token(kind: .number, value: "2", sourceIndex: 3),
+                Token(kind: .number("1"), sourceIndex: 0),
+                Token(kind: .reserved(.notEqual), sourceIndex: 1),
+                Token(kind: .number("2"), sourceIndex: 3)
             ])
 
-            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "1", sourceIndex: 0))
-            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "2", sourceIndex: 3))
-            let rootNode = Node(kind: .notEqual, left: leftNode, right: rightNode, token: Token(kind: .notEqual, value: "!=", sourceIndex: 1))
+            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
+            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 3))
+            let rootNode = Node(kind: .notEqual, left: leftNode, right: rightNode, token: Token(kind: .reserved(.notEqual), sourceIndex: 1))
 
             XCTAssertEqual(
                 node,
@@ -142,14 +142,14 @@ final class ParserTest: XCTestCase {
 
         try XCTContext.runActivity(named: "greaterThan") { _ in
             let node = try parse(tokens: [
-                Token(kind: .number, value: "1", sourceIndex: 0),
-                Token(kind: .greaterThan, value: ">", sourceIndex: 1),
-                Token(kind: .number, value: "2", sourceIndex: 2),
+                Token(kind: .number("1"), sourceIndex: 0),
+                Token(kind: .reserved(.greaterThan), sourceIndex: 1),
+                Token(kind: .number("2"), sourceIndex: 2)
             ])
 
-            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "1", sourceIndex: 0))
-            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "2", sourceIndex: 2))
-            let rootNode = Node(kind: .lessThan, left: rightNode, right: leftNode, token: Token(kind: .greaterThan, value: ">", sourceIndex: 1))
+            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
+            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 2))
+            let rootNode = Node(kind: .lessThan, left: rightNode, right: leftNode, token: Token(kind: .reserved(.greaterThan), sourceIndex: 1))
 
             XCTAssertEqual(
                 node,
@@ -159,14 +159,14 @@ final class ParserTest: XCTestCase {
 
         try XCTContext.runActivity(named: "greaterThanOrEqual") { _ in
             let node = try parse(tokens: [
-                Token(kind: .number, value: "1", sourceIndex: 0),
-                Token(kind: .greaterThanOrEqual, value: ">=", sourceIndex: 1),
-                Token(kind: .number, value: "2", sourceIndex: 3),
+                Token(kind: .number("1"), sourceIndex: 0),
+                Token(kind: .reserved(.greaterThanOrEqual), sourceIndex: 1),
+                Token(kind: .number("2"), sourceIndex: 3)
             ])
 
-            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "1", sourceIndex: 0))
-            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "2", sourceIndex: 3))
-            let rootNode = Node(kind: .lessThanOrEqual, left: rightNode, right: leftNode, token: Token(kind: .greaterThanOrEqual, value: ">=", sourceIndex: 1))
+            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
+            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 3))
+            let rootNode = Node(kind: .lessThanOrEqual, left: rightNode, right: leftNode, token: Token(kind: .reserved(.greaterThanOrEqual), sourceIndex: 1))
 
             XCTAssertEqual(
                 node,
@@ -176,14 +176,14 @@ final class ParserTest: XCTestCase {
 
         try XCTContext.runActivity(named: "lessThan") { _ in
             let node = try parse(tokens: [
-                Token(kind: .number, value: "1", sourceIndex: 0),
-                Token(kind: .lessThan, value: "<", sourceIndex: 1),
-                Token(kind: .number, value: "2", sourceIndex: 2),
+                Token(kind: .number("1"), sourceIndex: 0),
+                Token(kind: .reserved(.lessThan), sourceIndex: 1),
+                Token(kind: .number("2"), sourceIndex: 2)
             ])
 
-            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "1", sourceIndex: 0))
-            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "2", sourceIndex: 2))
-            let rootNode = Node(kind: .lessThan, left: leftNode, right: rightNode, token: Token(kind: .lessThan, value: "<", sourceIndex: 1))
+            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
+            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 2))
+            let rootNode = Node(kind: .lessThan, left: leftNode, right: rightNode, token: Token(kind: .reserved(.lessThan), sourceIndex: 1))
 
             XCTAssertEqual(
                 node,
@@ -193,14 +193,14 @@ final class ParserTest: XCTestCase {
 
         try XCTContext.runActivity(named: "lessThanOrEqual") { _ in
             let node = try parse(tokens: [
-                Token(kind: .number, value: "1", sourceIndex: 0),
-                Token(kind: .lessThanOrEqual, value: "<=", sourceIndex: 1),
-                Token(kind: .number, value: "2", sourceIndex: 3),
+                Token(kind: .number("1"), sourceIndex: 0),
+                Token(kind: .reserved(.lessThanOrEqual), sourceIndex: 1),
+                Token(kind: .number("2"), sourceIndex: 3)
             ])
 
-            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "1", sourceIndex: 0))
-            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number, value: "2", sourceIndex: 3))
-            let rootNode = Node(kind: .lessThanOrEqual, left: leftNode, right: rightNode, token: Token(kind: .lessThanOrEqual, value: "<=", sourceIndex: 1))
+            let leftNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("1"), sourceIndex: 0))
+            let rightNode = Node(kind: .number, left: nil, right: nil, token: Token(kind: .number("2"), sourceIndex: 3))
+            let rootNode = Node(kind: .lessThanOrEqual, left: leftNode, right: rightNode, token: Token(kind: .reserved(.lessThanOrEqual), sourceIndex: 1))
 
             XCTAssertEqual(
                 node,

--- a/Tests/TokenizerTest/TokenizerTest.swift
+++ b/Tests/TokenizerTest/TokenizerTest.swift
@@ -8,7 +8,7 @@ final class TokenizerTest: XCTestCase {
         XCTAssertEqual(
             tokens,
             [
-                Token(kind: .number, value: "5", sourceIndex: 0)
+                Token(kind: .number("5"), sourceIndex: 0)
             ]
         )
     }
@@ -18,7 +18,7 @@ final class TokenizerTest: XCTestCase {
         XCTAssertEqual(
             tokens,
             [
-                Token(kind: .number, value: "123", sourceIndex: 0)
+                Token(kind: .number("123"), sourceIndex: 0)
             ]
         )
     }
@@ -28,9 +28,9 @@ final class TokenizerTest: XCTestCase {
         XCTAssertEqual(
             tokens,
             [
-                Token(kind: .number, value: "1", sourceIndex: 0),
-                Token(kind: .add, value: "+", sourceIndex: 2),
-                Token(kind: .number, value: "23", sourceIndex: 6)
+                Token(kind: .number("1"), sourceIndex: 0),
+                Token(kind: .reserved(.add), sourceIndex: 2),
+                Token(kind: .number("23"), sourceIndex: 6)
             ]
         )
     }
@@ -40,21 +40,21 @@ final class TokenizerTest: XCTestCase {
         XCTAssertEqual(
             tokens,
             [
-                Token(kind: .number, value: "1", sourceIndex: 0),
-                Token(kind: .add, value: "+", sourceIndex: 1),
-                Token(kind: .number, value: "2", sourceIndex: 2),
-                Token(kind: .sub, value: "-", sourceIndex: 3),
-                Token(kind: .number, value: "3", sourceIndex: 4),
-                Token(kind: .mul, value: "*", sourceIndex: 5),
-                Token(kind: .number, value: "4", sourceIndex: 6),
-                Token(kind: .div, value: "/", sourceIndex: 7),
-                Token(kind: .number, value: "5", sourceIndex: 8),
-                Token(kind: .add, value: "+", sourceIndex: 9),
-                Token(kind: .parenthesisLeft, value: "(", sourceIndex: 10),
-                Token(kind: .number, value: "1", sourceIndex: 11),
-                Token(kind: .add, value: "+", sourceIndex: 12),
-                Token(kind: .number, value: "2", sourceIndex: 13),
-                Token(kind: .parenthesisRight, value: ")", sourceIndex: 14),
+                Token(kind: .number("1"), sourceIndex: 0),
+                Token(kind: .reserved(.add), sourceIndex: 1),
+                Token(kind: .number("2"), sourceIndex: 2),
+                Token(kind: .reserved(.sub), sourceIndex: 3),
+                Token(kind: .number("3"), sourceIndex: 4),
+                Token(kind: .reserved(.mul), sourceIndex: 5),
+                Token(kind: .number("4"), sourceIndex: 6),
+                Token(kind: .reserved(.div), sourceIndex: 7),
+                Token(kind: .number("5"), sourceIndex: 8),
+                Token(kind: .reserved(.add), sourceIndex: 9),
+                Token(kind: .reserved(.parenthesisLeft), sourceIndex: 10),
+                Token(kind: .number("1"), sourceIndex: 11),
+                Token(kind: .reserved(.add), sourceIndex: 12),
+                Token(kind: .number("2"), sourceIndex: 13),
+                Token(kind: .reserved(.parenthesisRight), sourceIndex: 14)
             ]
         )
     }
@@ -65,9 +65,9 @@ final class TokenizerTest: XCTestCase {
             XCTAssertEqual(
                 tokens,
                 [
-                    Token(kind: .number, value: "1", sourceIndex: 0),
-                    Token(kind: .equal, value: "==", sourceIndex: 1),
-                    Token(kind: .number, value: "2", sourceIndex: 3)
+                    Token(kind: .number("1"), sourceIndex: 0),
+                    Token(kind: .reserved(.equal), sourceIndex: 1),
+                    Token(kind: .number("2"), sourceIndex: 3)
                 ]
             )
         }
@@ -77,9 +77,9 @@ final class TokenizerTest: XCTestCase {
             XCTAssertEqual(
                 tokens,
                 [
-                    Token(kind: .number, value: "1", sourceIndex: 0),
-                    Token(kind: .notEqual, value: "!=", sourceIndex: 1),
-                    Token(kind: .number, value: "2", sourceIndex: 3)
+                    Token(kind: .number("1"), sourceIndex: 0),
+                    Token(kind: .reserved(.notEqual), sourceIndex: 1),
+                    Token(kind: .number("2"), sourceIndex: 3)
                 ]
             )
         }
@@ -89,9 +89,9 @@ final class TokenizerTest: XCTestCase {
             XCTAssertEqual(
                 tokens,
                 [
-                    Token(kind: .number, value: "1", sourceIndex: 0),
-                    Token(kind: .greaterThan, value: ">", sourceIndex: 1),
-                    Token(kind: .number, value: "2", sourceIndex: 2)
+                    Token(kind: .number("1"), sourceIndex: 0),
+                    Token(kind: .reserved(.greaterThan), sourceIndex: 1),
+                    Token(kind: .number("2"), sourceIndex: 2)
                 ]
             )
         }
@@ -101,9 +101,9 @@ final class TokenizerTest: XCTestCase {
             XCTAssertEqual(
                 tokens,
                 [
-                    Token(kind: .number, value: "1", sourceIndex: 0),
-                    Token(kind: .greaterThanOrEqual, value: ">=", sourceIndex: 1),
-                    Token(kind: .number, value: "2", sourceIndex: 3)
+                    Token(kind: .number("1"), sourceIndex: 0),
+                    Token(kind: .reserved(.greaterThanOrEqual), sourceIndex: 1),
+                    Token(kind: .number("2"), sourceIndex: 3)
                 ]
             )
         }
@@ -113,9 +113,9 @@ final class TokenizerTest: XCTestCase {
             XCTAssertEqual(
                 tokens,
                 [
-                    Token(kind: .number, value: "1", sourceIndex: 0),
-                    Token(kind: .lessThan, value: "<", sourceIndex: 1),
-                    Token(kind: .number, value: "2", sourceIndex: 2)
+                    Token(kind: .number("1"), sourceIndex: 0),
+                    Token(kind: .reserved(.lessThan), sourceIndex: 1),
+                    Token(kind: .number("2"), sourceIndex: 2)
                 ]
             )
         }
@@ -125,9 +125,9 @@ final class TokenizerTest: XCTestCase {
             XCTAssertEqual(
                 tokens,
                 [
-                    Token(kind: .number, value: "1", sourceIndex: 0),
-                    Token(kind: .lessThanOrEqual, value: "<=", sourceIndex: 1),
-                    Token(kind: .number, value: "2", sourceIndex: 3)
+                    Token(kind: .number("1"), sourceIndex: 0),
+                    Token(kind: .reserved(.lessThanOrEqual), sourceIndex: 1),
+                    Token(kind: .number("2"), sourceIndex: 3)
                 ]
             )
         }

--- a/Tests/TokenizerTest/TokenizerTest.swift
+++ b/Tests/TokenizerTest/TokenizerTest.swift
@@ -8,7 +8,7 @@ final class TokenizerTest: XCTestCase {
         XCTAssertEqual(
             tokens,
             [
-                Token(kind: .number("5"), sourceIndex: 0)
+                .number("5", sourceIndex: 0)
             ]
         )
     }
@@ -18,7 +18,7 @@ final class TokenizerTest: XCTestCase {
         XCTAssertEqual(
             tokens,
             [
-                Token(kind: .number("123"), sourceIndex: 0)
+                .number("123", sourceIndex: 0)
             ]
         )
     }
@@ -28,9 +28,9 @@ final class TokenizerTest: XCTestCase {
         XCTAssertEqual(
             tokens,
             [
-                Token(kind: .number("1"), sourceIndex: 0),
-                Token(kind: .reserved(.add), sourceIndex: 2),
-                Token(kind: .number("23"), sourceIndex: 6)
+                .number("1", sourceIndex: 0),
+                .reserved(.add, sourceIndex: 2),
+                .number("23", sourceIndex: 6)
             ]
         )
     }
@@ -40,21 +40,21 @@ final class TokenizerTest: XCTestCase {
         XCTAssertEqual(
             tokens,
             [
-                Token(kind: .number("1"), sourceIndex: 0),
-                Token(kind: .reserved(.add), sourceIndex: 1),
-                Token(kind: .number("2"), sourceIndex: 2),
-                Token(kind: .reserved(.sub), sourceIndex: 3),
-                Token(kind: .number("3"), sourceIndex: 4),
-                Token(kind: .reserved(.mul), sourceIndex: 5),
-                Token(kind: .number("4"), sourceIndex: 6),
-                Token(kind: .reserved(.div), sourceIndex: 7),
-                Token(kind: .number("5"), sourceIndex: 8),
-                Token(kind: .reserved(.add), sourceIndex: 9),
-                Token(kind: .reserved(.parenthesisLeft), sourceIndex: 10),
-                Token(kind: .number("1"), sourceIndex: 11),
-                Token(kind: .reserved(.add), sourceIndex: 12),
-                Token(kind: .number("2"), sourceIndex: 13),
-                Token(kind: .reserved(.parenthesisRight), sourceIndex: 14)
+                .number("1", sourceIndex: 0),
+                .reserved(.add, sourceIndex: 1),
+                .number("2", sourceIndex: 2),
+                .reserved(.sub, sourceIndex: 3),
+                .number("3", sourceIndex: 4),
+                .reserved(.mul, sourceIndex: 5),
+                .number("4", sourceIndex: 6),
+                .reserved(.div, sourceIndex: 7),
+                .number("5", sourceIndex: 8),
+                .reserved(.add, sourceIndex: 9),
+                .reserved(.parenthesisLeft, sourceIndex: 10),
+                .number("1", sourceIndex: 11),
+                .reserved(.add, sourceIndex: 12),
+                .number("2", sourceIndex: 13),
+                .reserved(.parenthesisRight, sourceIndex: 14)
             ]
         )
     }
@@ -65,9 +65,9 @@ final class TokenizerTest: XCTestCase {
             XCTAssertEqual(
                 tokens,
                 [
-                    Token(kind: .number("1"), sourceIndex: 0),
-                    Token(kind: .reserved(.equal), sourceIndex: 1),
-                    Token(kind: .number("2"), sourceIndex: 3)
+                    .number("1", sourceIndex: 0),
+                    .reserved(.equal, sourceIndex: 1),
+                    .number("2", sourceIndex: 3)
                 ]
             )
         }
@@ -77,9 +77,9 @@ final class TokenizerTest: XCTestCase {
             XCTAssertEqual(
                 tokens,
                 [
-                    Token(kind: .number("1"), sourceIndex: 0),
-                    Token(kind: .reserved(.notEqual), sourceIndex: 1),
-                    Token(kind: .number("2"), sourceIndex: 3)
+                    .number("1", sourceIndex: 0),
+                    .reserved(.notEqual, sourceIndex: 1),
+                    .number("2", sourceIndex: 3)
                 ]
             )
         }
@@ -89,9 +89,9 @@ final class TokenizerTest: XCTestCase {
             XCTAssertEqual(
                 tokens,
                 [
-                    Token(kind: .number("1"), sourceIndex: 0),
-                    Token(kind: .reserved(.greaterThan), sourceIndex: 1),
-                    Token(kind: .number("2"), sourceIndex: 2)
+                    .number("1", sourceIndex: 0),
+                    .reserved(.greaterThan, sourceIndex: 1),
+                    .number("2", sourceIndex: 2)
                 ]
             )
         }
@@ -101,9 +101,9 @@ final class TokenizerTest: XCTestCase {
             XCTAssertEqual(
                 tokens,
                 [
-                    Token(kind: .number("1"), sourceIndex: 0),
-                    Token(kind: .reserved(.greaterThanOrEqual), sourceIndex: 1),
-                    Token(kind: .number("2"), sourceIndex: 3)
+                    .number("1", sourceIndex: 0),
+                    .reserved(.greaterThanOrEqual, sourceIndex: 1),
+                    .number("2", sourceIndex: 3)
                 ]
             )
         }
@@ -113,9 +113,9 @@ final class TokenizerTest: XCTestCase {
             XCTAssertEqual(
                 tokens,
                 [
-                    Token(kind: .number("1"), sourceIndex: 0),
-                    Token(kind: .reserved(.lessThan), sourceIndex: 1),
-                    Token(kind: .number("2"), sourceIndex: 2)
+                    .number("1", sourceIndex: 0),
+                    .reserved(.lessThan, sourceIndex: 1),
+                    .number("2", sourceIndex: 2)
                 ]
             )
         }
@@ -125,9 +125,9 @@ final class TokenizerTest: XCTestCase {
             XCTAssertEqual(
                 tokens,
                 [
-                    Token(kind: .number("1"), sourceIndex: 0),
-                    Token(kind: .reserved(.lessThanOrEqual), sourceIndex: 1),
-                    Token(kind: .number("2"), sourceIndex: 3)
+                    .number("1", sourceIndex: 0),
+                    .reserved(.lessThanOrEqual, sourceIndex: 1),
+                    .number("2", sourceIndex: 3)
                 ]
             )
         }


### PR DESCRIPTION
# 概要
- トークナイズ時に予約後のチェックを一つ一つリテラルで行っていので、CaseIteratableとRawValueを活用することで、enum定義に予約語を追加するだけでトークナイズできる仕組みを作る

# 実装
- `Token`をenumに
    - `number(String, sourceIndex)`: 整数リテラル
    - `reserved(Token.Kind.ReservedKind, sourceIndex)`: 予約語
- `Token.Kind.ReservedKind`を`CaseIteratable`に準拠させ、`RawValue`で予約後のリテラルを定義する
    - `Tokenizer`で`ReservedKind.allCases`に対してforを利用しトークナイズ