### PR TITLE
ParserのNodeの設計を見直す

### DIFF
--- a/Sources/Parser/Node.swift
+++ b/Sources/Parser/Node.swift
@@ -1,82 +1,232 @@
 import Tokenizer
 
-public final class Node: Equatable {
+public enum NodeKind {
+    case integerLiteral
+    case identifier
 
-    // MARK: - Property
+    case binaryOperator
+    case assign
 
+    case infixOperatorExpr
+    case ifStatement
+    case whileStatement
+    case forStatement
+    case returnStatement
+}
+
+public protocol NodeProtocol: Equatable {
+    var sourceTokens: [Token] { get }
+    var kind: NodeKind { get }
+}
+
+public final class AnyNode: NodeProtocol {
+
+    public let sourceTokens: [Token]
     public let kind: NodeKind
 
-    public var left: Node?
-    public var right: Node?
-
-    public let token: Token
-
-    // MARK: - Initializer
-
-    public init(kind: NodeKind, left: Node?, right: Node?, token: Token) {
-        self.kind = kind
-        self.left = left
-        self.right = right
-        self.token = token
+    init(_ node: any NodeProtocol) {
+        self.sourceTokens = node.sourceTokens
+        self.kind = node.kind
     }
 
-    public static func == (lhs: Node, rhs: Node) -> Bool {
-        lhs.kind == rhs.kind && lhs.left == rhs.left && lhs.right == rhs.right && lhs.token == rhs.token
+    convenience init?(_ node: (any NodeProtocol)?) {
+        guard let node else { return nil }
+
+        self.init(node)
+    }
+
+    public static func == (lhs: AnyNode, rhs: AnyNode) -> Bool {
+        lhs.sourceTokens == rhs.sourceTokens && lhs.kind == rhs.kind
     }
 }
 
-public enum NodeKind: Equatable {
-    /// `+`
-    case add
+public class IntegerLiteralNode: NodeProtocol {
 
-    /// `-`
-    case sub
+    // MARK: - Property
 
-    /// `*`
-    case mul
+    public let kind: NodeKind = .integerLiteral
 
-    /// `/`
-    case div
+    public let sourceTokens: [Token]
+    public var token: Token
 
-    /// integer e.g. 1, 123
-    case number
+    public var literal: String {
+        token.value
+    }
 
-    /// `==`
-    case equal
+    // MARK: - Initializer
 
-    /// `!=`
-    case notEqual
+    init(token: Token) {
+        self.token = token
+        self.sourceTokens = [token]
+    }
 
-    /// `<`
-    case lessThan
+    public static func == (lhs: IntegerLiteralNode, rhs: IntegerLiteralNode) -> Bool {
+        lhs.kind == rhs.kind && lhs.token == rhs.token
+    }
+}
 
-    /// `<=`
-    case lessThanOrEqual
+public class IdentifierNode: NodeProtocol {
 
-    /// assign to var e.g: a = 10
-    case assign
+    // MARK: - Property
 
-    /// local variable
-    case localVariable
+    public var kind: NodeKind = .identifier
 
-    /// return statement
-    case `return`
+    public let sourceTokens: [Token]
+    public var token: Token
 
-    /// while statement
-    case `while`
+    public var identifierName: String {
+        token.value
+    }
 
-    /// if statement
-    case `if`
+    // MARK: - Initializer
 
-    /// if else statement
-    case `else`
+    init(token: Token) {
+        self.token = token
+        self.sourceTokens = [token]
+    }
 
-    /// for statement start
-    case `for`
+    public static func == (lhs: IdentifierNode, rhs: IdentifierNode) -> Bool {
+        lhs.kind == rhs.kind && lhs.token == rhs.token
+    }
+}
 
-    /// for statement condintion
-    case forCondition
+public class BinaryOperatorNode: NodeProtocol {
 
-    /// for body
-    case forBody
+    public enum OperatorKind {
+        /// `+`
+        case add
+
+        /// `-`
+        case sub
+
+        /// `*`
+        case mul
+
+        /// `/`
+        case div
+
+        /// `==`
+        case equal
+
+        /// `!=`
+        case notEqual
+
+        /// `<`
+        case lessThan
+
+        /// `<=`
+        case lessThanOrEqual
+
+        /// `>`
+        case greaterThan
+
+        /// `>=`
+        case greaterThanOrEqual
+    }
+
+    // MARK: - Property
+
+    public var kind: NodeKind = .binaryOperator
+
+    public var operatorKind: OperatorKind {
+        switch token {
+        case .reserved(.add, _):
+            return .add
+
+        case .reserved(.sub, _):
+            return .sub
+
+        case .reserved(.mul, _):
+            return .mul
+
+        case .reserved(.div, _):
+            return .div
+
+        case .reserved(.equal, _):
+            return .equal
+
+        case .reserved(.notEqual, _):
+            return .notEqual
+
+        case .reserved(.lessThan, _):
+            return .lessThan
+
+        case .reserved(.lessThanOrEqual, _):
+            return .lessThanOrEqual
+
+        case .reserved(.greaterThan, _):
+            return .greaterThan
+
+        case .reserved(.greaterThanOrEqual, _):
+            return .greaterThanOrEqual
+
+        default:
+            fatalError()
+        }
+    }
+    public let sourceTokens: [Token]
+    public var token: Token
+
+    // MARK: - Initializer
+
+    init(token: Token) {
+        self.token = token
+        self.sourceTokens = [token]
+    }
+
+    public static func == (lhs: BinaryOperatorNode, rhs: BinaryOperatorNode) -> Bool {
+        lhs.token == rhs.token && lhs.kind == rhs.kind
+    }
+}
+
+public class AssignNode: NodeProtocol {
+
+    // MARK: - Property
+
+    public var kind: NodeKind = .assign
+
+    public let sourceTokens: [Token]
+    public var token: Token
+
+    // MARK: - Initializer
+
+    init(token: Token) {
+        self.token = token
+        self.sourceTokens = [token]
+    }
+
+    public static func == (lhs: AssignNode, rhs: AssignNode) -> Bool {
+        lhs.token == rhs.token
+    }
+}
+
+public class InfixOperatorExpressionNode: NodeProtocol {
+
+    // MARK: - Property
+
+    public var kind: NodeKind = .infixOperatorExpr
+
+    public var left: any NodeProtocol
+    public var right: any NodeProtocol
+
+    public var `operator`: any NodeProtocol
+
+    public let sourceTokens: [Token]
+
+    // MARK: - Initializer
+
+    init(operator: any NodeProtocol, left: any NodeProtocol, right: any NodeProtocol, sourceTokens: [Token]) {
+        self.operator = `operator`
+        self.left = left
+        self.right = right
+        self.sourceTokens = sourceTokens
+    }
+
+    public static func == (lhs: InfixOperatorExpressionNode, rhs: InfixOperatorExpressionNode) -> Bool {
+        lhs.sourceTokens == rhs.sourceTokens
+        && lhs.kind == rhs.kind
+        && AnyNode(lhs.left) == AnyNode(rhs.left)
+        && AnyNode(lhs.right) == AnyNode(rhs.right)
+        && AnyNode(lhs.operator) == AnyNode(rhs.operator)
+    }
 }

--- a/Sources/Parser/Node.swift
+++ b/Sources/Parser/Node.swift
@@ -36,7 +36,7 @@ public final class AnyNode: NodeProtocol {
     }
 
     public static func == (lhs: AnyNode, rhs: AnyNode) -> Bool {
-        lhs.sourceTokens == rhs.sourceTokens && lhs.kind == rhs.kind
+        lhs.kind == rhs.kind && lhs.sourceTokens == rhs.sourceTokens
     }
 }
 
@@ -61,7 +61,7 @@ public class IntegerLiteralNode: NodeProtocol {
     }
 
     public static func == (lhs: IntegerLiteralNode, rhs: IntegerLiteralNode) -> Bool {
-        lhs.kind == rhs.kind && lhs.token == rhs.token
+        lhs.token == rhs.token
     }
 }
 
@@ -86,7 +86,7 @@ public class IdentifierNode: NodeProtocol {
     }
 
     public static func == (lhs: IdentifierNode, rhs: IdentifierNode) -> Bool {
-        lhs.kind == rhs.kind && lhs.token == rhs.token
+        lhs.token == rhs.token
     }
 }
 
@@ -175,7 +175,7 @@ public class BinaryOperatorNode: NodeProtocol {
     }
 
     public static func == (lhs: BinaryOperatorNode, rhs: BinaryOperatorNode) -> Bool {
-        lhs.token == rhs.token && lhs.kind == rhs.kind
+        lhs.token == rhs.token
     }
 }
 
@@ -224,7 +224,6 @@ public class InfixOperatorExpressionNode: NodeProtocol {
 
     public static func == (lhs: InfixOperatorExpressionNode, rhs: InfixOperatorExpressionNode) -> Bool {
         lhs.sourceTokens == rhs.sourceTokens
-        && lhs.kind == rhs.kind
         && AnyNode(lhs.left) == AnyNode(rhs.left)
         && AnyNode(lhs.right) == AnyNode(rhs.right)
         && AnyNode(lhs.operator) == AnyNode(rhs.operator)

--- a/Sources/Parser/StatementNode.swift
+++ b/Sources/Parser/StatementNode.swift
@@ -19,7 +19,6 @@ public class WhileStatementNode: NodeProtocol {
 
     public static func == (lhs: WhileStatementNode, rhs: WhileStatementNode) -> Bool {
         lhs.sourceTokens == rhs.sourceTokens
-        && lhs.kind == rhs.kind
         && AnyNode(lhs.condition) == AnyNode(rhs.condition)
         && AnyNode(lhs.body) == AnyNode(rhs.body)
     }
@@ -49,7 +48,6 @@ public class ForStatementNode: NodeProtocol {
 
     public static func == (lhs: ForStatementNode, rhs: ForStatementNode) -> Bool {
         lhs.sourceTokens == rhs.sourceTokens
-        && lhs.kind == rhs.kind
         && AnyNode(lhs.condition) == AnyNode(rhs.condition)
         && AnyNode(lhs.pre) == AnyNode(rhs.pre)
         && AnyNode(lhs.post) == AnyNode(rhs.post)
@@ -81,7 +79,6 @@ public class IfStatementNode: NodeProtocol {
 
     public static func == (lhs: IfStatementNode, rhs: IfStatementNode) -> Bool {
         lhs.sourceTokens == rhs.sourceTokens
-        && lhs.kind == rhs.kind
         && AnyNode(lhs.condition) == AnyNode(rhs.condition)
         && AnyNode(lhs.trueBody) == AnyNode(rhs.trueBody)
         && AnyNode(lhs.falseBody) == AnyNode(rhs.falseBody)
@@ -105,7 +102,6 @@ public class ReturnStatementNode: NodeProtocol {
 
     public static func == (lhs: ReturnStatementNode, rhs: ReturnStatementNode) -> Bool {
         lhs.sourceTokens == rhs.sourceTokens
-        && lhs.kind == rhs.kind
         && AnyNode(lhs.expression) == AnyNode(rhs.expression)
     }
 }

--- a/Sources/Parser/StatementNode.swift
+++ b/Sources/Parser/StatementNode.swift
@@ -1,0 +1,112 @@
+import Tokenizer
+
+public class WhileStatementNode: NodeProtocol {
+
+    public var kind: NodeKind = .whileStatement
+
+    public let token: Token
+    public let sourceTokens: [Token]
+
+    public var condition: any NodeProtocol
+    public var body: any NodeProtocol
+
+    init(token: Token, condition: any NodeProtocol, body: any NodeProtocol, sourceTokens: [Token]) {
+        self.token = token
+        self.condition = condition
+        self.body = body
+        self.sourceTokens = sourceTokens
+    }
+
+    public static func == (lhs: WhileStatementNode, rhs: WhileStatementNode) -> Bool {
+        lhs.sourceTokens == rhs.sourceTokens
+        && lhs.kind == rhs.kind
+        && AnyNode(lhs.condition) == AnyNode(rhs.condition)
+        && AnyNode(lhs.body) == AnyNode(rhs.body)
+    }
+}
+
+public class ForStatementNode: NodeProtocol {
+
+    public var kind: NodeKind = .forStatement
+
+    public let token: Token
+
+    public var condition: (any NodeProtocol)?
+    public var pre: (any NodeProtocol)?
+    public var post: (any NodeProtocol)?
+    public var body: any NodeProtocol
+
+    public let sourceTokens: [Token]
+
+    init(token: Token, condition: (any NodeProtocol)?, pre: (any NodeProtocol)?, post: (any NodeProtocol)?, body: any NodeProtocol, sourceTokens: [Token]) {
+        self.token = token
+        self.condition = condition
+        self.pre = pre
+        self.post = post
+        self.body = body
+        self.sourceTokens = sourceTokens
+    }
+
+    public static func == (lhs: ForStatementNode, rhs: ForStatementNode) -> Bool {
+        lhs.sourceTokens == rhs.sourceTokens
+        && lhs.kind == rhs.kind
+        && AnyNode(lhs.condition) == AnyNode(rhs.condition)
+        && AnyNode(lhs.pre) == AnyNode(rhs.pre)
+        && AnyNode(lhs.post) == AnyNode(rhs.post)
+        && AnyNode(lhs.body) == AnyNode(rhs.body)
+    }
+}
+
+public class IfStatementNode: NodeProtocol {
+
+    public var kind: NodeKind = .ifStatement
+
+    public let ifToken: Token
+    public let elseToken: Token?
+
+    public var condition: any NodeProtocol
+    public var trueBody: any NodeProtocol
+    public var falseBody: (any NodeProtocol)?
+
+    public let sourceTokens: [Token]
+
+    init(ifToken: Token, condition: any NodeProtocol, trueBody: any NodeProtocol, elseToken: Token?, falseBody: (any NodeProtocol)?, sourceTokens: [Token]) {
+        self.ifToken = ifToken
+        self.condition = condition
+        self.trueBody = trueBody
+        self.elseToken = elseToken
+        self.falseBody = falseBody
+        self.sourceTokens = sourceTokens
+    }
+
+    public static func == (lhs: IfStatementNode, rhs: IfStatementNode) -> Bool {
+        lhs.sourceTokens == rhs.sourceTokens
+        && lhs.kind == rhs.kind
+        && AnyNode(lhs.condition) == AnyNode(rhs.condition)
+        && AnyNode(lhs.trueBody) == AnyNode(rhs.trueBody)
+        && AnyNode(lhs.falseBody) == AnyNode(rhs.falseBody)
+    }
+}
+
+public class ReturnStatementNode: NodeProtocol {
+
+    public var kind: NodeKind = .returnStatement
+    public let token: Token
+
+    public var expression: any NodeProtocol
+
+    public let sourceTokens: [Token]
+
+    init(token: Token, expression: any NodeProtocol, sourceTokens: [Token]) {
+        self.token = token
+        self.expression = expression
+        self.sourceTokens = sourceTokens
+    }
+
+    public static func == (lhs: ReturnStatementNode, rhs: ReturnStatementNode) -> Bool {
+        lhs.sourceTokens == rhs.sourceTokens
+        && lhs.kind == rhs.kind
+        && AnyNode(lhs.expression) == AnyNode(rhs.expression)
+    }
+}
+

--- a/Tests/ParserTest/AssignTest.swift
+++ b/Tests/ParserTest/AssignTest.swift
@@ -5,62 +5,70 @@ import Tokenizer
 final class AssignTest: XCTestCase {
 
     func testAssignToVar() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .identifier("a", sourceIndex: 0),
             .reserved(.assign, sourceIndex: 1),
             .number("2", sourceIndex: 2),
             .reserved(.semicolon, sourceIndex: 3)
-        ])[0]
-
-        let leftNode = Node(kind: .localVariable, left: nil, right: nil, token: .identifier("a", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
-        let rootNode = Node(kind: .assign, left: leftNode, right: rightNode, token: .reserved(.assign, sourceIndex: 1))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: AssignNode(token: tokens[1]),
+                left: IdentifierNode(token: tokens[0]),
+                right: IntegerLiteralNode(token: tokens[2]), 
+                sourceTokens: Array(tokens[0...2])
+            )
         )
     }
 
     func testAssignTo2Var() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .identifier("a", sourceIndex: 0),
             .reserved(.assign, sourceIndex: 1),
             .identifier("b", sourceIndex: 2),
             .reserved(.assign, sourceIndex: 3),
             .number("2", sourceIndex: 4),
             .reserved(.semicolon, sourceIndex: 5)
-        ])[0]
-
-        let childLeft = Node(kind: .localVariable, left: nil, right: nil, token: .identifier("b", sourceIndex: 2))
-        let childRight = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 4))
-        let childNode = Node(kind: .assign, left: childLeft, right: childRight, token: .reserved(.assign, sourceIndex: 3))
-
-        let leftNode = Node(kind: .localVariable, left: nil, right: nil, token: .identifier("a", sourceIndex: 0))
-        let rootNode = Node(kind: .assign, left: leftNode, right: childNode, token: .reserved(.assign, sourceIndex: 1))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: AssignNode(token: tokens[1]),
+                left: IdentifierNode(token: tokens[0]),
+                right: InfixOperatorExpressionNode(
+                    operator: AssignNode(token: tokens[3]),
+                    left: IdentifierNode(token: tokens[2]),
+                    right: IntegerLiteralNode(token: tokens[4]), 
+                    sourceTokens: Array(tokens[2...4])
+                ),
+                sourceTokens: Array(tokens[0...4])
+            )
         )
     }
 
     // 数への代入は文法上は許される、意味解析で排除する
     func testAssingToNumber() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.assign, sourceIndex: 1),
             .number("2", sourceIndex: 2),
             .reserved(.semicolon, sourceIndex: 3)
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
-        let rootNode = Node(kind: .assign, left: leftNode, right: rightNode, token: .reserved(.assign, sourceIndex: 1))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: AssignNode(token: tokens[1]),
+                left: IntegerLiteralNode(token: tokens[0]),
+                right: IntegerLiteralNode(token: tokens[2]),
+                sourceTokens: Array(tokens[0...2])
+            )
         )
     }
 }

--- a/Tests/ParserTest/Control/ForTest.swift
+++ b/Tests/ParserTest/Control/ForTest.swift
@@ -5,7 +5,7 @@ import Tokenizer
 final class ForTest: XCTestCase {
 
     func testFor() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .keyword(.for, sourceIndex: 0),
             .reserved(.parenthesisLeft, sourceIndex: 3),
             .number("1", sourceIndex: 4),
@@ -16,23 +16,24 @@ final class ForTest: XCTestCase {
             .reserved(.parenthesisRight, sourceIndex: 9),
             .number("4", sourceIndex: 10),
             .reserved(.semicolon, sourceIndex: 11)
-        ])[0]
+        ]
+        let node = try parse(tokens: tokens)[0]
 
-        let postExpr = Node(kind: .number, left: nil, right: nil, token: .number("3", sourceIndex: 8))
-        let statement = Node(kind: .number, left: nil, right: nil, token: .number("4", sourceIndex: 10))
-        let forBody = Node(kind: .forBody, left: statement, right: postExpr, token: .keyword(.for, sourceIndex: 0))
-
-        let condition = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 6))
-        let forCondition = Node(kind: .forCondition, left: condition, right: forBody, token: .keyword(.for, sourceIndex: 0))
-
-        let preExpr = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 4))
-        let forRoot = Node(kind: .for, left: preExpr, right: forCondition, token: .keyword(.for, sourceIndex: 0))
-
-        XCTAssertEqual(node, forRoot)
+        XCTAssertEqual(
+            node as! ForStatementNode,
+            ForStatementNode(
+                token: tokens[0],
+                condition: IntegerLiteralNode(token: tokens[4]),
+                pre: IntegerLiteralNode(token: tokens[2]),
+                post: IntegerLiteralNode(token: tokens[6]),
+                body: IntegerLiteralNode(token: tokens[8]),
+                sourceTokens: Array(tokens[0...9])
+            )
+        )
     }
 
     func testForNoNodes() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .keyword(.for, sourceIndex: 0),
             .reserved(.parenthesisLeft, sourceIndex: 3),
             .reserved(.semicolon, sourceIndex: 4),
@@ -40,15 +41,19 @@ final class ForTest: XCTestCase {
             .reserved(.parenthesisRight, sourceIndex: 6),
             .number("4", sourceIndex: 7),
             .reserved(.semicolon, sourceIndex: 8)
-        ])[0]
+        ]
+        let node = try parse(tokens: tokens)[0]
 
-        let statement = Node(kind: .number, left: nil, right: nil, token: .number("4", sourceIndex: 7))
-        let forBody = Node(kind: .forBody, left: statement, right: nil, token: .keyword(.for, sourceIndex: 0))
-
-        let forCondition = Node(kind: .forCondition, left: nil, right: forBody, token: .keyword(.for, sourceIndex: 0))
-
-        let forRoot = Node(kind: .for, left: nil, right: forCondition, token: .keyword(.for, sourceIndex: 0))
-
-        XCTAssertEqual(node, forRoot)
+        XCTAssertEqual(
+            node as! ForStatementNode,
+            ForStatementNode(
+                token: tokens[0],
+                condition: nil,
+                pre: nil,
+                post: nil,
+                body: IntegerLiteralNode(token: tokens[5]),
+                sourceTokens: Array(tokens[0...6])
+            )
+        )
     }
 }

--- a/Tests/ParserTest/Control/IfTest.swift
+++ b/Tests/ParserTest/Control/IfTest.swift
@@ -5,24 +5,31 @@ import Tokenizer
 final class IfTest: XCTestCase {
 
     func testIf() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .keyword(.if, sourceIndex: 0),
             .reserved(.parenthesisLeft, sourceIndex: 2),
             .number("1", sourceIndex: 3),
             .reserved(.parenthesisRight, sourceIndex: 4),
             .number("2", sourceIndex: 5),
             .reserved(.semicolon, sourceIndex: 6)
-        ])[0]
+        ]
+        let node = try parse(tokens: tokens)[0]
 
-        let condition = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 3))
-        let trueStatement = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 5))
-        let ifNode = Node(kind: .if, left: condition, right: trueStatement, token: .keyword(.if, sourceIndex: 0))
-
-        XCTAssertEqual(node, ifNode)
+        XCTAssertEqual(
+            node as! IfStatementNode,
+            IfStatementNode(
+                ifToken: tokens[0],
+                condition: IntegerLiteralNode(token: tokens[2]),
+                trueBody: IntegerLiteralNode(token: tokens[4]),
+                elseToken: nil,
+                falseBody: nil,
+                sourceTokens: Array(tokens[0...5])
+            )
+        )
     }
 
     func testIfElse() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .keyword(.if, sourceIndex: 0),
             .reserved(.parenthesisLeft, sourceIndex: 2),
             .number("1", sourceIndex: 3),
@@ -32,15 +39,19 @@ final class IfTest: XCTestCase {
             .keyword(.else, sourceIndex: 7),
             .number("3", sourceIndex: 8),
             .reserved(.semicolon, sourceIndex: 9)
-        ])[0]
+        ]
+        let node = try parse(tokens: tokens)[0]
 
-        let condition = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 3))
-        let trueStatement = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 5))
-        let falseStatement = Node(kind: .number, left: nil, right: nil, token: .number("3", sourceIndex: 8))
-
-        let elseNode = Node(kind: .else, left: trueStatement, right: falseStatement, token: .keyword(.else, sourceIndex: 7))
-        let ifNode = Node(kind: .if, left: condition, right: elseNode, token: .keyword(.if, sourceIndex: 0))
-
-        XCTAssertEqual(node, ifNode)
+        XCTAssertEqual(
+            node as! IfStatementNode,
+            IfStatementNode(
+                ifToken: tokens[0],
+                condition: IntegerLiteralNode(token: tokens[2]),
+                trueBody: IntegerLiteralNode(token: tokens[4]),
+                elseToken: tokens[6],
+                falseBody: IntegerLiteralNode(token: tokens[7]),
+                sourceTokens: Array(tokens[0...8])
+            )
+        )
     }
 }

--- a/Tests/ParserTest/Control/WhileTest.swift
+++ b/Tests/ParserTest/Control/WhileTest.swift
@@ -5,20 +5,25 @@ import Tokenizer
 final class WhileTest: XCTestCase {
 
     func testWhile() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .keyword(.while, sourceIndex: 0),
             .reserved(.parenthesisLeft, sourceIndex: 5),
             .number("1", sourceIndex: 6),
             .reserved(.parenthesisRight, sourceIndex: 7),
             .number("2", sourceIndex: 8),
             .reserved(.semicolon, sourceIndex: 9)
-        ])[0]
+        ]
+        let node = try parse(tokens: tokens)[0]
 
-        let condition = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 6))
-        let statement = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 8))
-        let whileNode = Node(kind: .while, left: condition, right: statement, token: .keyword(.while, sourceIndex: 0))
-
-        XCTAssertEqual(node, whileNode)
+        XCTAssertEqual(
+            node as! WhileStatementNode,
+            WhileStatementNode(
+                token: tokens[0],
+                condition: IntegerLiteralNode(token: tokens[2]),
+                body: IntegerLiteralNode(token: tokens[4]),
+                sourceTokens: Array(tokens[0...5])
+            )
+        )
     }
 
     func testWhileNoExpr() throws {

--- a/Tests/ParserTest/MultiStatementTest.swift
+++ b/Tests/ParserTest/MultiStatementTest.swift
@@ -5,18 +5,19 @@ import Tokenizer
 final class MultiStatementTest: XCTestCase {
 
     func test2Statement() throws {
-        let nodes = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.semicolon, sourceIndex: 1),
             .number("2", sourceIndex: 2),
             .reserved(.semicolon, sourceIndex: 3),
-        ])
+        ]
+        let nodes = try parse(tokens: tokens)
 
         XCTAssertEqual(
-            nodes,
+            nodes as! [IntegerLiteralNode],
             [
-                Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0)),
-                Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2)),
+                IntegerLiteralNode(token: tokens[0]),
+                IntegerLiteralNode(token: tokens[2])
             ]
         )
     }

--- a/Tests/ParserTest/OperatorPriorityTest.swift
+++ b/Tests/ParserTest/OperatorPriorityTest.swift
@@ -5,76 +5,88 @@ import Tokenizer
 final class OperatorPriorityTest: XCTestCase {
 
     func testAddPriority() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.add, sourceIndex: 1),
             .number("2", sourceIndex: 2),
             .reserved(.add, sourceIndex: 3),
             .number("3", sourceIndex: 4),
             .reserved(.semicolon, sourceIndex: 5),
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
-        let addNode = Node(kind: .add, left: leftNode, right: rightNode, token: .reserved(.add, sourceIndex: 1))
-
-        let rightNode2 = Node(kind: .number, left: nil, right: nil, token: .number("3", sourceIndex: 4))
-        let rootNode = Node(kind: .add, left: addNode, right: rightNode2, token: .reserved(.add, sourceIndex: 3))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[3]),
+                left: InfixOperatorExpressionNode(
+                    operator: BinaryOperatorNode(token: tokens[1]),
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    right: IntegerLiteralNode(token: tokens[2]),
+                    sourceTokens: Array(tokens[0...2])
+                ),
+                right: IntegerLiteralNode(token: tokens[4]),
+                sourceTokens: Array(tokens[0...4])
+            )
         )
     }
 
     func testMulPriority() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.mul, sourceIndex: 1),
             .number("2", sourceIndex: 2),
             .reserved(.mul, sourceIndex: 3),
             .number("3", sourceIndex: 4),
             .reserved(.semicolon, sourceIndex: 5),
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
-        let addNode = Node(kind: .mul, left: leftNode, right: rightNode, token: .reserved(.mul, sourceIndex: 1))
-
-        let rightNode2 = Node(kind: .number, left: nil, right: nil, token: .number("3", sourceIndex: 4))
-        let rootNode = Node(kind: .mul, left: addNode, right: rightNode2, token: .reserved(.mul, sourceIndex: 3))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[3]),
+                left: InfixOperatorExpressionNode(
+                    operator: BinaryOperatorNode(token: tokens[1]),
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    right: IntegerLiteralNode(token: tokens[2]),
+                    sourceTokens: Array(tokens[0...2])
+                ),
+                right: IntegerLiteralNode(token: tokens[4]),
+                sourceTokens: Array(tokens[0...4])
+            )
         )
     }
 
     func testAddAndMulPriority() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.add, sourceIndex: 1),
             .number("2", sourceIndex: 2),
             .reserved(.mul, sourceIndex: 3),
             .number("3", sourceIndex: 4),
             .reserved(.semicolon, sourceIndex: 5),
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("3", sourceIndex: 4))
-        let mulNode = Node(kind: .mul, left: leftNode, right: rightNode, token: .reserved(.mul, sourceIndex: 3))
-
-        let leftNode2 = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
-        let rootNode = Node(kind: .add, left: leftNode2, right: mulNode, token: .reserved(.add, sourceIndex: 1))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[1]),
+                left: IntegerLiteralNode(token: tokens[0]),
+                right: InfixOperatorExpressionNode(
+                    operator: BinaryOperatorNode(token: tokens[3]),
+                    left: IntegerLiteralNode(token: tokens[2]),
+                    right: IntegerLiteralNode(token: tokens[4]),
+                    sourceTokens: Array(tokens[2...4])
+                ),
+                sourceTokens: Array(tokens[0...4])
+            )
         )
     }
 
     func testParenthesisPriority() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .reserved(.parenthesisLeft, sourceIndex: 0),
             .number("1", sourceIndex: 1),
             .reserved(.add, sourceIndex: 2),
@@ -83,18 +95,22 @@ final class OperatorPriorityTest: XCTestCase {
             .reserved(.mul, sourceIndex: 5),
             .number("3", sourceIndex: 6),
             .reserved(.semicolon, sourceIndex: 7),
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 1))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 3))
-        let addNode = Node(kind: .add, left: leftNode, right: rightNode, token: .reserved(.add, sourceIndex: 2))
-
-        let rightNode2 = Node(kind: .number, left: nil, right: nil, token: .number("3", sourceIndex: 6))
-        let rootNode = Node(kind: .mul, left: addNode, right: rightNode2, token: .reserved(.mul, sourceIndex: 5))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[5]),
+                left: InfixOperatorExpressionNode(
+                    operator: BinaryOperatorNode(token: tokens[3]),
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    right: IntegerLiteralNode(token: tokens[2]), 
+                    sourceTokens: Array(tokens[1...3])
+                ),
+                right: IntegerLiteralNode(token: tokens[6]),
+                sourceTokens: Array(tokens[0...6])
+            )
         )
     }
 }

--- a/Tests/ParserTest/OperatorsTest.swift
+++ b/Tests/ParserTest/OperatorsTest.swift
@@ -5,214 +5,235 @@ import Tokenizer
 final class OperatorsTest: XCTestCase {
 
     func testAdd() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.add, sourceIndex: 1),
             .number("2", sourceIndex: 2),
             .reserved(.semicolon, sourceIndex: 3)
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
-        let rootNode = Node(kind: .add, left: leftNode, right: rightNode, token: .reserved(.add, sourceIndex: 1))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[1]),
+                left: IntegerLiteralNode(token: tokens[0]),
+                right: IntegerLiteralNode(token: tokens[2]),
+                sourceTokens: Array(tokens[0...2])
+            )
         )
     }
 
     func testSub() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.sub, sourceIndex: 1),
             .number("2", sourceIndex: 2),
             .reserved(.semicolon, sourceIndex: 3)
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
-        let rootNode = Node(kind: .sub, left: leftNode, right: rightNode, token: .reserved(.sub, sourceIndex: 1))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[1]),
+                left: IntegerLiteralNode(token: tokens[0]),
+                right: IntegerLiteralNode(token: tokens[2]),
+                sourceTokens: Array(tokens[0...2])
+            )
         )
     }
 
     func testMul() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.mul, sourceIndex: 1),
             .number("2", sourceIndex: 2),
             .reserved(.semicolon, sourceIndex: 3)
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
-        let rootNode = Node(kind: .mul, left: leftNode, right: rightNode, token: .reserved(.mul, sourceIndex: 1))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[1]),
+                left: IntegerLiteralNode(token: tokens[0]),
+                right: IntegerLiteralNode(token: tokens[2]),
+                sourceTokens: Array(tokens[0...2])
+            )
         )
     }
 
     func testDiv() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.div, sourceIndex: 1),
             .number("2", sourceIndex: 2),
             .reserved(.semicolon, sourceIndex: 3)
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
-        let rootNode = Node(kind: .div, left: leftNode, right: rightNode, token: .reserved(.div, sourceIndex: 1))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[1]),
+                left: IntegerLiteralNode(token: tokens[0]),
+                right: IntegerLiteralNode(token: tokens[2]),
+                sourceTokens: Array(tokens[0...2])
+            )
         )
     }
 
     func testUnaryAdd() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .reserved(.add, sourceIndex: 0),
             .number("1", sourceIndex: 1),
             .reserved(.semicolon, sourceIndex: 2)
-        ])[0]
-
-        let numberNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 1))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            numberNode
+            node as! IntegerLiteralNode,
+            IntegerLiteralNode(token: tokens[1])
         )
     }
 
     func testUnarySub() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .reserved(.sub, sourceIndex: 0),
             .number("1", sourceIndex: 1),
             .reserved(.semicolon, sourceIndex: 2)
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("0", sourceIndex: 1))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 1))
-        let rootNode = Node(kind: .sub, left: leftNode, right: rightNode, token: .reserved(.sub, sourceIndex: 0))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[0]),
+                left: IntegerLiteralNode(token: .number("0", sourceIndex: 1)),
+                right: IntegerLiteralNode(token: tokens[1]),
+                sourceTokens: Array(tokens[0...1])
+            )
         )
     }
 
     func testEqual() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.equal, sourceIndex: 1),
             .number("2", sourceIndex: 3),
             .reserved(.semicolon, sourceIndex: 4)
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 3))
-        let rootNode = Node(kind: .equal, left: leftNode, right: rightNode, token: .reserved(.equal, sourceIndex: 1))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[1]),
+                left: IntegerLiteralNode(token: tokens[0]),
+                right: IntegerLiteralNode(token: tokens[2]),
+                sourceTokens: Array(tokens[0...2])
+            )
         )
     }
 
     func testNotEqual() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.notEqual, sourceIndex: 1),
             .number("2", sourceIndex: 3),
-            .reserved(.semicolon, sourceIndex: 3)
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 3))
-        let rootNode = Node(kind: .notEqual, left: leftNode, right: rightNode, token: .reserved(.notEqual, sourceIndex: 1))
+            .reserved(.semicolon, sourceIndex: 4)
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[1]),
+                left: IntegerLiteralNode(token: tokens[0]),
+                right: IntegerLiteralNode(token: tokens[2]),
+                sourceTokens: Array(tokens[0...2])
+            )
         )
     }
 
     func testGreaterThan() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.greaterThan, sourceIndex: 1),
             .number("2", sourceIndex: 2),
             .reserved(.semicolon, sourceIndex: 3)
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
-        let rootNode = Node(kind: .lessThan, left: rightNode, right: leftNode, token: .reserved(.greaterThan, sourceIndex: 1))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[1]),
+                left: IntegerLiteralNode(token: tokens[0]),
+                right: IntegerLiteralNode(token: tokens[2]),
+                sourceTokens: Array(tokens[0...2])
+            )
         )
     }
 
     func testGreaterThanOrEqual() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.greaterThanOrEqual, sourceIndex: 1),
             .number("2", sourceIndex: 3),
             .reserved(.semicolon, sourceIndex: 4)
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 3))
-        let rootNode = Node(kind: .lessThanOrEqual, left: rightNode, right: leftNode, token: .reserved(.greaterThanOrEqual, sourceIndex: 1))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[1]),
+                left: IntegerLiteralNode(token: tokens[0]),
+                right: IntegerLiteralNode(token: tokens[2]),
+                sourceTokens: Array(tokens[0...2])
+            )
         )
     }
 
     func testLessThan() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.lessThan, sourceIndex: 1),
             .number("2", sourceIndex: 2),
             .reserved(.semicolon, sourceIndex: 3)
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 2))
-        let rootNode = Node(kind: .lessThan, left: leftNode, right: rightNode, token: .reserved(.lessThan, sourceIndex: 1))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[1]),
+                left: IntegerLiteralNode(token: tokens[0]),
+                right: IntegerLiteralNode(token: tokens[2]),
+                sourceTokens: Array(tokens[0...2])
+            )
         )
     }
 
     func testLessThanOrEqual() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .number("1", sourceIndex: 0),
             .reserved(.lessThanOrEqual, sourceIndex: 1),
             .number("2", sourceIndex: 3),
             .reserved(.semicolon, sourceIndex: 4)
-        ])[0]
-
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("1", sourceIndex: 0))
-        let rightNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 3))
-        let rootNode = Node(kind: .lessThanOrEqual, left: leftNode, right: rightNode, token: .reserved(.lessThanOrEqual, sourceIndex: 1))
+        ]
+        let node = try parse(tokens: tokens)[0]
 
         XCTAssertEqual(
-            node,
-            rootNode
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: BinaryOperatorNode(token: tokens[1]),
+                left: IntegerLiteralNode(token: tokens[0]),
+                right: IntegerLiteralNode(token: tokens[2]),
+                sourceTokens: Array(tokens[0...2])
+            )
         )
     }
 }

--- a/Tests/ParserTest/ReturnTest.swift
+++ b/Tests/ParserTest/ReturnTest.swift
@@ -5,16 +5,21 @@ import Tokenizer
 final class ReturnTest: XCTestCase {
 
     func testReturn() throws {
-        let node = try parse(tokens: [
+        let tokens: [Token] = [
             .keyword(.return, sourceIndex: 0),
             .number("2", sourceIndex: 6),
             .reserved(.semicolon, sourceIndex: 7),
-        ])[0]
+        ]
+        let node = try parse(tokens: tokens)[0]
 
-        let leftNode = Node(kind: .number, left: nil, right: nil, token: .number("2", sourceIndex: 6))
-        let returnNode = Node(kind: .return, left: leftNode, right: nil, token: .keyword(.return, sourceIndex: 0))
-
-        XCTAssertEqual(node, returnNode)
+        XCTAssertEqual(
+            node as! ReturnStatementNode,
+            ReturnStatementNode(
+                token: tokens[0],
+                expression: IntegerLiteralNode(token: tokens[1]),
+                sourceTokens: Array(tokens[0...1])
+            )
+        )
     }
 
     func testReturnNoExpr() throws {

--- a/Tests/TokenizerTest/TokensTest.swift
+++ b/Tests/TokenizerTest/TokensTest.swift
@@ -50,7 +50,7 @@ final class TokensTest: XCTestCase {
         )
     }
 
-    func testparenthesis() throws {
+    func testParenthesis() throws {
         let tokens = try tokenize(source: "(1)")
         XCTAssertEqual(
             tokens,


### PR DESCRIPTION
# 概要
- 従来はNodeを二分木の`class Node`のみで行っていた
    - 2つ以上個を持ちたい場合で問題がある: Forはpre, condition, post, bodyの4つのNodeを持ちたい
- Nodeの種類ごとに具体的な型を作成する

# 実装
- `NodeProtocol`: 全てのNodeが実装するProtocol
    - souceTokens: 該当部分のトークン全て
    - kind: Node型と一対一対応したenum
- `InfixOperatorExpressionNode`: 真ん中にOperatorがあるNode
    - left, right, operatorは`any Equatable`で保持

# 備考
- 子Nodeの比較は`AnyNode`にeraseして`souceTokens`, `kind`を比較
    - 何も持たせないと`any NodeProtocol`と`any NodeProtocol`の比較で困った
- 具体型でもこれら以外の`stored property`は基本持たない
    - 子Nodeの比較で正確に比較できず困るため

 - ジェネリクスを使うと、型パズル地獄になるためExisitentialでNodeを保持

型表現周りがマシにはなったが微妙なので少しづつSwiftSyntaxを見ながら解決していく