### PR TITLE
ステップ18: ポインタ型を導入する

### DIFF
--- a/Sources/Generator/Generator.swift
+++ b/Sources/Generator/Generator.swift
@@ -286,10 +286,11 @@ public final class Generator {
                 // *のあとはどんな値でも良い
                 result += try generate(node: casted.right)
 
-                // アドレスの値をロードしてpush
+                // 値をロードしてpush
                 result += "    ldr x0, [sp]\n"
                 result += "    add sp, sp, #16\n"
 
+                // 値をアドレスとして読み、アドレスが指す値をロード
                 result += "    ldr x0, [x0]\n"
                 result += "    str x0, [sp, #-16]!\n"
 
@@ -308,7 +309,15 @@ public final class Generator {
             let casted = try node.casted(InfixOperatorExpressionNode.self)
 
             if casted.operator is AssignNode {
-                result += try generatePushLocalVariableAddress(node: casted.left.casted(IdentifierNode.self))
+                // 左辺は変数か、`*変数`
+                if let identifier = casted.left as? IdentifierNode {
+                    result += try generatePushLocalVariableAddress(node: casted.left.casted(IdentifierNode.self))
+                } else if let pointer = casted.left as? PrefixOperatorExpressionNode, pointer.operatorKind == .reference {
+                    result += try generate(node: pointer.right)
+                } else {
+                    throw GenerateError.invalidSyntax(index: casted.left.sourceTokens[0].sourceIndex)
+                }
+
                 result += try generate(node: casted.right)
 
                 // 両方のノードの結果をpop
@@ -322,7 +331,6 @@ public final class Generator {
                 result += "    str x0, [x1]\n"
 
                 result += "    str x0, [sp, #-16]!\n"
-
 
             } else if let binaryOperator = casted.operator as? BinaryOperatorNode {
                 result += try generate(node: casted.left)

--- a/Sources/Generator/Generator.swift
+++ b/Sources/Generator/Generator.swift
@@ -144,6 +144,13 @@ public final class Generator {
 
             return ""
 
+        case .pointerType:
+            // 今は型の一致を見ていない
+            fatalError()
+
+        case .type:
+            fatalError()
+
         case .blockStatement:
             let casted = try node.casted(BlockStatementNode.self)
 

--- a/Sources/Parser/Node.swift
+++ b/Sources/Parser/Node.swift
@@ -4,6 +4,9 @@ public enum NodeKind {
     case integerLiteral
     case identifier
 
+    case type
+    case pointerType
+
     case binaryOperator
     case assign
 
@@ -291,5 +294,41 @@ public class FunctionCallExpressionNode: NodeProtocol {
         self.token = token
         self.arguments = arguments
         self.sourceTokens = sourceTokens
+    }
+}
+
+public class TypeNode: NodeProtocol {
+
+    // MARK: - Property
+
+    public let kind: NodeKind = .type
+    public var sourceTokens: [Token] { [typeToken] }
+    public let children: [any NodeProtocol] = []
+
+    public let typeToken: Token
+
+    // MARK: - Initializer
+
+    public init(typeToken: Token) {
+        self.typeToken = typeToken
+    }
+}
+
+public class PointerTypeNode: NodeProtocol {
+
+    // MARK: - Property
+
+    public let kind: NodeKind = .pointerType
+    public var sourceTokens: [Token] { referenceType.sourceTokens + [pointerToken] }
+    public var children: [any NodeProtocol] { [referenceType] }
+    public let referenceType: any NodeProtocol
+
+    public let pointerToken: Token
+
+    // MARK: - Initializer
+
+    init(referenceType: any NodeProtocol, pointerToken: Token) {
+        self.referenceType = referenceType
+        self.pointerToken = pointerToken
     }
 }

--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -123,7 +123,7 @@ public final class Parser {
         }
         let startIndex = index
 
-        let returnType = try consumeTypeToken()
+        let returnType = try type()
 
         let functionName = try consumeIdentifierToken()
         try consumeReservedToken(.parenthesisLeft)
@@ -136,7 +136,7 @@ public final class Parser {
         try consumeReservedToken(.parenthesisRight)
 
         return FunctionDeclNode(
-            returnTypeToken: returnType,
+            returnType: returnType,
             token: functionName,
             block: try block(),
             parameters: parameters,
@@ -284,9 +284,25 @@ public final class Parser {
     // variableDecl = type identifier
     func variableDecl() throws -> VariableDeclNode {
         VariableDeclNode(
-            typeToken: try consumeTypeToken(),
+            type: try type(),
             identifierToken: try consumeIdentifierToken()
         )
+    }
+
+    // type = typeIdentifier "*"*
+    func type() throws -> any NodeProtocol {
+        var node: any NodeProtocol = TypeNode(typeToken: try consumeTypeToken())
+
+        while index < tokens.count {
+            if case .reserved(.mul, _) = tokens[index] {
+                let mulToken = try consumeReservedToken(.mul)
+                node = PointerTypeNode(referenceType: node, pointerToken: mulToken)
+            } else {
+                break
+            }
+        }
+
+        return node
     }
 
     // expr = assign

--- a/Sources/Parser/StatementNode.swift
+++ b/Sources/Parser/StatementNode.swift
@@ -134,24 +134,10 @@ public class FunctionDeclNode: NodeProtocol {
     public let sourceTokens: [Token]
     public var children: [any NodeProtocol] { [block] + parameters }
 
-    public let returnTypeToken: Token
+    public let returnType: any NodeProtocol
     public let token: Token
     public let block: BlockStatementNode
     public let parameters: [VariableDeclNode]
-
-    public var returnTypeName: String {
-        returnTypeToken.value
-    }
-
-    public var returnTypeKind: Token.TypeKind {
-        switch returnTypeToken {
-        case .type(let kind, _):
-            return kind
-
-        default:
-            fatalError()
-        }
-    }
 
     public var functionName: String {
         token.value
@@ -159,8 +145,8 @@ public class FunctionDeclNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(returnTypeToken: Token, token: Token, block: BlockStatementNode, parameters: [VariableDeclNode], sourceTokens: [Token]) {
-        self.returnTypeToken = returnTypeToken
+    init(returnType: any NodeProtocol, token: Token, block: BlockStatementNode, parameters: [VariableDeclNode], sourceTokens: [Token]) {
+        self.returnType = returnType
         self.token = token
         self.block = block
         self.parameters = parameters
@@ -172,34 +158,23 @@ public class VariableDeclNode: NodeProtocol {
 
     // MARK: - Property
 
-
     public var kind: NodeKind = .variableDecl
     public var sourceTokens: [Token] {
-        [typeToken, identifierToken]
+        type.sourceTokens + [identifierToken]
     }
     public let children: [any NodeProtocol] = []
 
-    public let typeToken: Token
+    public let type: any NodeProtocol
     public let identifierToken: Token
 
     public var identifierName: String {
         identifierToken.value
     }
 
-    public var typeKind: Token.TypeKind {
-        switch typeToken {
-        case .type(let kind, _):
-            return kind
-
-        default:
-            fatalError()
-        }
-    }
-
     // MARK: - Initializer
 
-    init(typeToken: Token, identifierToken: Token) {
-        self.typeToken = typeToken
+    init(type: any NodeProtocol, identifierToken: Token) {
+        self.type = type
         self.identifierToken = identifierToken
     }
 }

--- a/Tests/ParserTest/FunctionTest.swift
+++ b/Tests/ParserTest/FunctionTest.swift
@@ -22,7 +22,7 @@ final class FunctionTest: XCTestCase {
         XCTAssertEqual(
             node,
             FunctionDeclNode(
-                returnTypeToken: tokens[0],
+                returnType: TypeNode(typeToken: tokens[0]),
                 token: tokens[1],
                 block: BlockStatementNode(
                     statements: [
@@ -30,6 +30,40 @@ final class FunctionTest: XCTestCase {
                         IntegerLiteralNode(token: tokens[7])
                     ],
                     sourceTokens: Array(tokens[4...9])
+                ),
+                parameters: [],
+                sourceTokens: tokens
+            )
+        )
+    }
+
+    func testFunctionDeclPointer() throws {
+        let tokens: [Token] = [
+            .type(.int, sourceIndex: 0),
+            .reserved(.mul, sourceIndex: 3),
+            .identifier("main", sourceIndex: 5),
+            .reserved(.parenthesisLeft, sourceIndex: 9),
+            .reserved(.parenthesisRight, sourceIndex: 10),
+            .reserved(.braceLeft, sourceIndex: 11),
+            .number("1", sourceIndex: 12),
+            .reserved(.semicolon, sourceIndex: 13),
+            .number("2", sourceIndex: 14),
+            .reserved(.semicolon, sourceIndex: 15),
+            .reserved(.braceRight, sourceIndex: 16)
+        ]
+        let node = try Parser(tokens: tokens).functionDecl()
+
+        XCTAssertEqual(
+            node,
+            FunctionDeclNode(
+                returnType: PointerTypeNode(referenceType: TypeNode(typeToken: tokens[0]), pointerToken: tokens[1]),
+                token: tokens[2],
+                block: BlockStatementNode(
+                    statements: [
+                        IntegerLiteralNode(token: tokens[6]),
+                        IntegerLiteralNode(token: tokens[8])
+                    ],
+                    sourceTokens: Array(tokens[5...10])
                 ),
                 parameters: [],
                 sourceTokens: tokens
@@ -73,7 +107,7 @@ final class FunctionTest: XCTestCase {
         XCTAssertEqual(
             node,
             FunctionDeclNode(
-                returnTypeToken: tokens[0],
+                returnType: TypeNode(typeToken: tokens[0]),
                 token: tokens[1],
                 block: BlockStatementNode(
                     statements: [
@@ -82,8 +116,8 @@ final class FunctionTest: XCTestCase {
                     sourceTokens: Array(tokens[9...12])
                 ),
                 parameters: [
-                    VariableDeclNode(typeToken: tokens[3], identifierToken: tokens[4]),
-                    VariableDeclNode(typeToken: tokens[6], identifierToken: tokens[7])
+                    VariableDeclNode(type: TypeNode(typeToken: tokens[3]), identifierToken: tokens[4]),
+                    VariableDeclNode(type: TypeNode(typeToken: tokens[6]), identifierToken: tokens[7])
                 ],
                 sourceTokens: tokens
             )
@@ -141,7 +175,7 @@ final class FunctionTest: XCTestCase {
             SourceFileNode(
                 functions: [
                     FunctionDeclNode(
-                        returnTypeToken: tokens[0],
+                        returnType: TypeNode(typeToken: tokens[0]),
                         token: tokens[1],
                         block: BlockStatementNode(
                             statements: [
@@ -153,7 +187,7 @@ final class FunctionTest: XCTestCase {
                         sourceTokens: Array(tokens[0...7])
                     ),
                     FunctionDeclNode(
-                        returnTypeToken: tokens[8],
+                        returnType: TypeNode(typeToken: tokens[8]),
                         token: tokens[9],
                         block: BlockStatementNode(
                             statements: [

--- a/Tests/ParserTest/VariableTest.swift
+++ b/Tests/ParserTest/VariableTest.swift
@@ -14,7 +14,38 @@ final class VariableTest: XCTestCase {
 
         XCTAssertEqual(
             node as! VariableDeclNode,
-            VariableDeclNode(typeToken: tokens[0], identifierToken: tokens[1])
+            VariableDeclNode(type: TypeNode(typeToken: tokens[0]), identifierToken: tokens[1])
+        )
+    }
+
+    func testDeclVariablePointer() throws {
+        let tokens: [Token] = [
+            .type(.int, sourceIndex: 0),
+            .reserved(.mul, sourceIndex: 3),
+            .identifier("a", sourceIndex: 5),
+            .reserved(.semicolon, sourceIndex: 6)
+        ]
+        let node = try Parser(tokens: tokens).stmt()
+
+        XCTAssertEqual(
+            node as! VariableDeclNode,
+            VariableDeclNode(type: PointerTypeNode(referenceType: TypeNode(typeToken: tokens[0]), pointerToken: tokens[1]), identifierToken: tokens[2])
+        )
+    }
+
+    func testDeclVariablePointer2() throws {
+        let tokens: [Token] = [
+            .type(.int, sourceIndex: 0),
+            .reserved(.mul, sourceIndex: 3),
+            .reserved(.mul, sourceIndex: 4),
+            .identifier("a", sourceIndex: 6),
+            .reserved(.semicolon, sourceIndex: 7)
+        ]
+        let node = try Parser(tokens: tokens).stmt()
+
+        XCTAssertEqual(
+            node as! VariableDeclNode,
+            VariableDeclNode(type: PointerTypeNode(referenceType: PointerTypeNode(referenceType: TypeNode(typeToken: tokens[0]), pointerToken: tokens[1]), pointerToken: tokens[2]) , identifierToken: tokens[3])
         )
     }
 }

--- a/test_exectable.sh
+++ b/test_exectable.sh
@@ -58,5 +58,8 @@ assert 74 "int sum(int a, int b, int c) { int d; d = 10; return a * 2 + b * 3 + 
 assert 5 "int main() { int a; int b; a = 5; b = &a; return *b; }"
 assert 5 "int main() { int a; a = 5; return *&a; }"
 assert 5 "int sub() { int a; a = 5; return a; } int main() { int a; a = 10; return sub(); }"
+assert 10 "int main() { int a; int* b; a = 5; b = &a; *b = 10; return a; }"
+assert 20 "int main() { int a; int* b; int** c; a = 5; b = &a; c = &b; **c = 20; return a; }"
+assert 30 "int main() { int a; int d; int* b; int** c; a = 5; d = 10; b = &a; c = &b; *c = &d; **c = 30; return d; }"
 
 echo OK


### PR DESCRIPTION
# 概要

https://www.sigbus.info/compilerbook#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9718-%E3%83%9D%E3%82%A4%E3%83%B3%E3%82%BF%E5%9E%8B%E3%82%92%E5%B0%8E%E5%85%A5%E3%81%99%E3%82%8B

# 実装

- 型の一致は現在検査していない
- ポインタ型を型として判断するのはParser
    - Tokenizerでも一応できるが以下の理由で不採用
        - Tokenizerに意味を持たせすぎないほうが正しい
        - 将来的にstructの型が出てきた時、結局Tokenizerではstructを型として認識できないので、ポインタ型としての認識もTokenizerでできない（はず）
        - SwiftのCSTでも`Type: [Int]`ではなく`ArrayType: Int`のNodeが作られていたため