### PR TITLE
ステップ22: 配列の添字を実装する

### DIFF
--- a/Sources/Parser/Node/ExpressionNode.swift
+++ b/Sources/Parser/Node/ExpressionNode.swift
@@ -1,0 +1,113 @@
+import Tokenizer
+
+public class InfixOperatorExpressionNode: NodeProtocol {
+
+    // MARK: - Property
+
+    public var kind: NodeKind = .infixOperatorExpr
+
+    public var left: any NodeProtocol
+    public var right: any NodeProtocol
+
+    public var `operator`: any NodeProtocol
+
+    public let sourceTokens: [Token]
+    public var children: [any NodeProtocol] { [left, right, `operator`] }
+
+    // MARK: - Initializer
+
+    init(operator: any NodeProtocol, left: any NodeProtocol, right: any NodeProtocol, sourceTokens: [Token]) {
+        self.operator = `operator`
+        self.left = left
+        self.right = right
+        self.sourceTokens = sourceTokens
+    }
+}
+
+public class PrefixOperatorExpressionNode: NodeProtocol {
+
+    public enum OperatorKind {
+        /// `*`
+        case reference
+
+        /// `&`
+        case address
+    }
+
+    // MARK: - Property
+
+    public var kind: NodeKind = .prefixOperatorExpr
+
+    public var operatorKind: OperatorKind {
+        switch `operator` {
+        case .reserved(.mul, _):
+            return .reference
+
+        case .reserved(.and, _):
+            return .address
+
+        default:
+            fatalError()
+        }
+    }
+
+    public let sourceTokens: [Token]
+    public var children: [any NodeProtocol] { [right] }
+    public let `operator`: Token
+
+    public let right: any NodeProtocol
+
+    // MARK: - Initializer
+
+    init(operator: Token, right: any NodeProtocol, sourceTokens: [Token]) {
+        self.operator = `operator`
+        self.right = right
+        self.sourceTokens = sourceTokens
+    }
+}
+
+public class FunctionCallExpressionNode: NodeProtocol {
+
+    // MARK: - Property
+
+    public var kind: NodeKind = .functionCallExpr
+    public let sourceTokens: [Token]
+    public var children: [any NodeProtocol] { arguments }
+
+    public let token: Token
+    public let arguments: [any NodeProtocol]
+    public var functionName: String {
+        token.value
+    }
+
+    // MARK: - Initializer
+
+    init(token: Token, arguments: [any NodeProtocol], sourceTokens: [Token]) {
+        self.token = token
+        self.arguments = arguments
+        self.sourceTokens = sourceTokens
+    }
+}
+
+public class SubscriptCallExpressionNode: NodeProtocol {
+
+    // MARK: - Property
+
+    public var kind: NodeKind = .subscriptCallExpr
+    public var sourceTokens: [Token] { [identifierToken, squareLeftToken] + argument.sourceTokens + [squareRightToken] }
+    public var children: [any NodeProtocol] { [argument] }
+
+    public let identifierToken: Token
+    public let squareLeftToken: Token
+    public let argument: any NodeProtocol
+    public let squareRightToken: Token
+
+    // MARK: - Initializer
+
+    public init(identifierToken: Token, squareLeftToken: Token, argument: any NodeProtocol, squareRightToken: Token) {
+        self.identifierToken = identifierToken
+        self.squareLeftToken = squareLeftToken
+        self.argument = argument
+        self.squareRightToken = squareRightToken
+    }
+}

--- a/Sources/Parser/Node/ExpressionNode.swift
+++ b/Sources/Parser/Node/ExpressionNode.swift
@@ -94,18 +94,18 @@ public class SubscriptCallExpressionNode: NodeProtocol {
     // MARK: - Property
 
     public var kind: NodeKind = .subscriptCallExpr
-    public var sourceTokens: [Token] { [identifierToken, squareLeftToken] + argument.sourceTokens + [squareRightToken] }
+    public var sourceTokens: [Token] { identifierNode.sourceTokens + [squareLeftToken] + argument.sourceTokens + [squareRightToken] }
     public var children: [any NodeProtocol] { [argument] }
 
-    public let identifierToken: Token
+    public let identifierNode: IdentifierNode
     public let squareLeftToken: Token
     public let argument: any NodeProtocol
     public let squareRightToken: Token
 
     // MARK: - Initializer
 
-    public init(identifierToken: Token, squareLeftToken: Token, argument: any NodeProtocol, squareRightToken: Token) {
-        self.identifierToken = identifierToken
+    public init(identifierNode: IdentifierNode, squareLeftToken: Token, argument: any NodeProtocol, squareRightToken: Token) {
+        self.identifierNode = identifierNode
         self.squareLeftToken = squareLeftToken
         self.argument = argument
         self.squareRightToken = squareRightToken

--- a/Sources/Parser/Node/Node.swift
+++ b/Sources/Parser/Node/Node.swift
@@ -14,6 +14,7 @@ public enum NodeKind {
     case prefixOperatorExpr
     case infixOperatorExpr
     case functionCallExpr
+    case subscriptCallExpr
 
     case ifStatement
     case whileStatement
@@ -206,94 +207,5 @@ public class AssignNode: NodeProtocol {
     init(token: Token) {
         self.token = token
         self.sourceTokens = [token]
-    }
-}
-
-public class InfixOperatorExpressionNode: NodeProtocol {
-
-    // MARK: - Property
-
-    public var kind: NodeKind = .infixOperatorExpr
-
-    public var left: any NodeProtocol
-    public var right: any NodeProtocol
-
-    public var `operator`: any NodeProtocol
-
-    public let sourceTokens: [Token]
-    public var children: [any NodeProtocol] { [left, right, `operator`] }
-
-    // MARK: - Initializer
-
-    init(operator: any NodeProtocol, left: any NodeProtocol, right: any NodeProtocol, sourceTokens: [Token]) {
-        self.operator = `operator`
-        self.left = left
-        self.right = right
-        self.sourceTokens = sourceTokens
-    }
-}
-
-public class PrefixOperatorExpressionNode: NodeProtocol {
-
-    public enum OperatorKind {
-        /// `*`
-        case reference
-
-        /// `&`
-        case address
-    }
-
-    // MARK: - Property
-
-    public var kind: NodeKind = .prefixOperatorExpr
-
-    public var operatorKind: OperatorKind {
-        switch `operator` {
-        case .reserved(.mul, _):
-            return .reference
-            
-        case .reserved(.and, _):
-            return .address
-
-        default:
-            fatalError()
-        }
-    }
-
-    public let sourceTokens: [Token]
-    public var children: [any NodeProtocol] { [right] }
-    public let `operator`: Token
-
-    public let right: any NodeProtocol
-
-    // MARK: - Initializer
-
-    init(operator: Token, right: any NodeProtocol, sourceTokens: [Token]) {
-        self.operator = `operator`
-        self.right = right
-        self.sourceTokens = sourceTokens
-    }
-}
-
-public class FunctionCallExpressionNode: NodeProtocol {
-
-    // MARK: - Property
-
-    public var kind: NodeKind = .functionCallExpr
-    public let sourceTokens: [Token]
-    public var children: [any NodeProtocol] { arguments }
-
-    public let token: Token
-    public let arguments: [any NodeProtocol]
-    public var functionName: String {
-        token.value
-    }
-
-    // MARK: - Initializer
-
-    init(token: Token, arguments: [any NodeProtocol], sourceTokens: [Token]) {
-        self.token = token
-        self.arguments = arguments
-        self.sourceTokens = sourceTokens
     }
 }

--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -627,7 +627,7 @@ public final class Parser {
                 return FunctionCallExpressionNode(token: identifierToken, arguments: argments, sourceTokens: Array(tokens[startIndex..<index]))
             } else if index < tokens.count, case .reserved(.squareLeft, _) = tokens[index] {
                 return SubscriptCallExpressionNode(
-                    identifierToken: identifierToken,
+                    identifierNode: IdentifierNode(token: identifierToken),
                     squareLeftToken: try consumeReservedToken(.squareLeft),
                     argument: try expr(),
                     squareRightToken: try consumeReservedToken(.squareRight)

--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -581,7 +581,9 @@ public final class Parser {
         }
     }
 
-    // primary = num | ident ( "( exprList? )" )? | "(" expr ")"
+    // primary = num
+    //         | ident ( ("( exprList? )") | ("[" expr "]") )?
+    //         | "(" expr ")"
     func primary() throws -> any NodeProtocol {
         if index >= tokens.count {
             throw ParseError.invalidSyntax(index: tokens.last.map { $0.sourceIndex + 1 } ?? 0)
@@ -623,6 +625,13 @@ public final class Parser {
                 try consumeReservedToken(.parenthesisRight)
 
                 return FunctionCallExpressionNode(token: identifierToken, arguments: argments, sourceTokens: Array(tokens[startIndex..<index]))
+            } else if index < tokens.count, case .reserved(.squareLeft, _) = tokens[index] {
+                return SubscriptCallExpressionNode(
+                    identifierToken: identifierToken,
+                    squareLeftToken: try consumeReservedToken(.squareLeft),
+                    argument: try expr(),
+                    squareRightToken: try consumeReservedToken(.squareRight)
+                )
             } else {
                 return IdentifierNode(token: identifierToken)
             }

--- a/Tests/ParserTest/FunctionTest.swift
+++ b/Tests/ParserTest/FunctionTest.swift
@@ -217,7 +217,7 @@ final class FunctionTest: XCTestCase {
         XCTAssertEqual(
             node as! SubscriptCallExpressionNode,
             SubscriptCallExpressionNode(
-                identifierToken: tokens[0],
+                identifierNode: IdentifierNode(token: tokens[0]),
                 squareLeftToken: tokens[1],
                 argument: IntegerLiteralNode(token: tokens[2]),
                 squareRightToken: tokens[3]
@@ -240,7 +240,7 @@ final class FunctionTest: XCTestCase {
         XCTAssertEqual(
             node as! SubscriptCallExpressionNode,
             SubscriptCallExpressionNode(
-                identifierToken: tokens[0],
+                identifierNode: IdentifierNode(token: tokens[0]),
                 squareLeftToken: tokens[1],
                 argument: InfixOperatorExpressionNode(
                     operator: BinaryOperatorNode(token: tokens[3]),

--- a/Tests/ParserTest/FunctionTest.swift
+++ b/Tests/ParserTest/FunctionTest.swift
@@ -203,4 +203,53 @@ final class FunctionTest: XCTestCase {
             )
         )
     }
+
+    func testSubscriptCall() throws {
+        let tokens: [Token] = [
+            .identifier("a", sourceIndex: 0),
+            .reserved(.squareLeft, sourceIndex: 1),
+            .number("1", sourceIndex: 2),
+            .reserved(.squareRight, sourceIndex: 3),
+            .reserved(.semicolon, sourceIndex: 4)
+        ]
+        let node = try Parser(tokens: tokens).stmt()
+
+        XCTAssertEqual(
+            node as! SubscriptCallExpressionNode,
+            SubscriptCallExpressionNode(
+                identifierToken: tokens[0],
+                squareLeftToken: tokens[1],
+                argument: IntegerLiteralNode(token: tokens[2]),
+                squareRightToken: tokens[3]
+            )
+        )
+    }
+
+    func testSubscriptCall2() throws {
+        let tokens: [Token] = [
+            .identifier("a", sourceIndex: 0),
+            .reserved(.squareLeft, sourceIndex: 1),
+            .number("1", sourceIndex: 2),
+            .reserved(.add, sourceIndex: 3),
+            .identifier("b", sourceIndex: 4),
+            .reserved(.squareRight, sourceIndex: 5),
+            .reserved(.semicolon, sourceIndex: 6)
+        ]
+        let node = try Parser(tokens: tokens).stmt()
+
+        XCTAssertEqual(
+            node as! SubscriptCallExpressionNode,
+            SubscriptCallExpressionNode(
+                identifierToken: tokens[0],
+                squareLeftToken: tokens[1],
+                argument: InfixOperatorExpressionNode(
+                    operator: BinaryOperatorNode(token: tokens[3]),
+                    left: IntegerLiteralNode(token: tokens[2]),
+                    right: IdentifierNode(token: tokens[4]),
+                    sourceTokens: Array(tokens[2...4])
+                ),
+                squareRightToken: tokens[5]
+            )
+        )
+    }
 }

--- a/test_exectable.sh
+++ b/test_exectable.sh
@@ -73,5 +73,11 @@ assert 2 "int main() { int a[2]; *(a + 1) = 2; return *(a + 1); }"
 assert 1 "int main() { int a[2]; int *p; p = a; return a == p; }"
 assert 5 "int main() { int a[2]; int *p; p = a; *(p + 1) = 5; return *(a + 1); }"
 assert 3 "int main() { int a[2]; *a = 1; *(a + 1) = 2; int *p; p = a; return *p + *(p + 1); }"
+assert 5 "int main() { int a[2]; a[0] = 5; return a[0]; }"
+assert 8 "int main() { int a; int* b; a = b + 1; int c; c = b; return a - c; }"
+assert 17 "int main() { int a[3]; int b; b = 1; a[b] = 7; a[b+1] = 10; return a[b] + a[b+1]; }"
+assert 5 "int main() { int a[2]; a[1] = 5; int* p; p = a; return p[1]; }"
+assert 5 "int main() { int a[2]; a[1] = 5; return *(a+1); }"
+assert 1 "int main() { int a[2]; a[1] = 5; int* p; p = a; return p[1] == *(p+1); }"
 
 echo OK


### PR DESCRIPTION
# 概要

https://www.sigbus.info/compilerbook#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9722-%E9%85%8D%E5%88%97%E3%81%AE%E6%B7%BB%E5%AD%97%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%99%E3%82%8B

# 実装

ASTの段階で`a[b]`を`*(a + b)`にすれば良いと書いてあったが、一応Swift風にしたかったので`SubscriptCallExpr`を導入