### PR TITLE
ステップ25: 文字列リテラルを実装する

### DIFF
--- a/Sources/Parser/Node/Node.swift
+++ b/Sources/Parser/Node/Node.swift
@@ -3,6 +3,7 @@ import Tokenizer
 public enum NodeKind {
     case integerLiteral
     case identifier
+    case stringLiteral
 
     case type
     case pointerType
@@ -73,6 +74,28 @@ public class IntegerLiteralNode: NodeProtocol {
     public var token: Token
 
     public var literal: String {
+        token.value
+    }
+
+    // MARK: - Initializer
+
+    init(token: Token) {
+        self.token = token
+        self.sourceTokens = [token]
+    }
+}
+
+public class StringLiteralNode: NodeProtocol {
+
+    // MARK: - Property
+
+    public let kind: NodeKind = .stringLiteral
+
+    public let sourceTokens: [Token]
+    public let children: [any NodeProtocol] = []
+    public var token: Token
+
+    public var value: String {
         token.value
     }
 

--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -48,6 +48,21 @@ public final class Parser {
     }
 
     @discardableResult
+    func consumeStringLiteralToken() throws -> Token {
+        if index >= tokens.count {
+            throw ParseError.invalidSyntax(index: tokens.last.map { $0.sourceIndex + 1 } ?? 0)
+        }
+
+        if case .stringLiteral = tokens[index] {
+            let token = tokens[index]
+            index += 1
+            return token
+        } else {
+            throw ParseError.invalidSyntax(index: tokens[index].sourceIndex)
+        }
+    }
+
+    @discardableResult
     func consumeReservedToken(_ reservedKind: Token.ReservedKind) throws -> Token {
         if index >= tokens.count {
             throw ParseError.invalidSyntax(index: tokens.last.map { $0.sourceIndex + 1 } ?? 0)
@@ -583,6 +598,7 @@ public final class Parser {
     }
 
     // primary = num
+    //         | stringLiteral
     //         | ident ( ("( exprList? )") | ("[" expr "]") )?
     //         | "(" expr ")"
     func primary() throws -> any NodeProtocol {
@@ -607,6 +623,12 @@ public final class Parser {
             let numberNode = IntegerLiteralNode(token: numberToken)
 
             return numberNode
+
+        case .stringLiteral:
+            let stringToken = try consumeStringLiteralToken()
+            let stringLiteralNode = StringLiteralNode(token: stringToken)
+
+            return stringLiteralNode
 
         case .identifier:
             let identifierToken = try consumeIdentifierToken()

--- a/Sources/Tokenizer/Token.swift
+++ b/Sources/Tokenizer/Token.swift
@@ -5,6 +5,7 @@ public enum Token: Equatable {
     case reserved(_ kind: ReservedKind, sourceIndex: Int)
     case keyword(_ kind: KeywordKind, sourceIndex: Int)
     case number(_ value: String, sourceIndex: Int)
+    case stringLiteral(_ value: String, sourceIndex: Int)
     case identifier(_ value: String, sourceIndex: Int)
     case type(_ kind: TypeKind, sourceIndex: Int)
 
@@ -17,6 +18,9 @@ public enum Token: Equatable {
             return kind.rawValue
 
         case .number(let value, _):
+            return value
+
+        case .stringLiteral(let value, _):
             return value
 
         case .identifier(let value, _):
@@ -36,6 +40,9 @@ public enum Token: Equatable {
             return sourceIndex
 
         case .number(_, let sourceIndex):
+            return sourceIndex
+
+        case .stringLiteral(_, let sourceIndex):
             return sourceIndex
 
         case .identifier(_, let sourceIndex):

--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -25,6 +25,28 @@ public func tokenize(source: String) throws -> [Token] {
         return .number(string, sourceIndex: startIndex)
     }
 
+    func extractString() -> Token {
+        var string = ""
+        let startIndex = index
+
+        // 開始の"
+        index += 1
+
+        while index < charactors.count {
+            let nextToken = charactors[index]
+
+            if nextToken == "\"" {
+                index += 1
+                break
+            } else {
+                string += String(nextToken)
+                index += 1
+            }
+        }
+
+        return .stringLiteral(string, sourceIndex: startIndex)
+    }
+
     func extractIdentifier() -> Token {
         var string = ""
         let startIndex = index
@@ -57,6 +79,11 @@ root:
 
         if charactors[index].isNumber {
             tokens.append(extractNumber())
+            continue
+        }
+
+        if charactors[index] == "\"" {
+            tokens.append(extractString())
             continue
         }
 

--- a/Tests/ParserTest/StringLiteralTest.swift
+++ b/Tests/ParserTest/StringLiteralTest.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import Parser
+import Tokenizer
+
+final class StringLiteralTest: XCTestCase {
+
+    func testStringLiteral1() throws {
+        let tokens: [Token] = [
+            .stringLiteral("a", sourceIndex: 0),
+            .reserved(.semicolon, sourceIndex: 1)
+        ]
+        let node = try Parser(tokens: tokens).stmt()
+
+        XCTAssertEqual(
+            node as! StringLiteralNode,
+            StringLiteralNode(token: tokens[0])
+        )
+    }
+
+    func testStringLiteral2() throws {
+        let tokens: [Token] = [
+            .identifier("a", sourceIndex: 0),
+            .reserved(.assign, sourceIndex: 1),
+            .stringLiteral("a", sourceIndex: 2),
+            .reserved(.semicolon, sourceIndex: 3)
+        ]
+        let node = try Parser(tokens: tokens).stmt()
+
+        XCTAssertEqual(
+            node as! InfixOperatorExpressionNode,
+            InfixOperatorExpressionNode(
+                operator: AssignNode(token: tokens[1]),
+                left: IdentifierNode(token: tokens[0]),
+                right: StringLiteralNode(token: tokens[2]),
+                sourceTokens: Array(tokens[0...2])
+            )
+        )
+    }
+}

--- a/Tests/TokenizerTest/StringLiteralTest.swift
+++ b/Tests/TokenizerTest/StringLiteralTest.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import Tokenizer
+
+final class StringLiteralTest: XCTestCase {
+
+    func testStringLiteral() throws {
+        let tokens = try tokenize(source: "\"aaaa\"")
+        XCTAssertEqual(
+            tokens,
+            [
+                .stringLiteral("aaaa", sourceIndex: 0)
+            ]
+        )
+    }
+}

--- a/test_exectable.sh
+++ b/test_exectable.sh
@@ -90,5 +90,9 @@ assert 15 "char x; int main() { x = 15; return x; }"
 assert 3 "char x[3]; int main() {  x[0] = -1; x[1] = 2; int y; y = 4; return x[0] + y; }"
 assert 150 "int main() { int x; x = 300; return x / 2; }"
 assert 22 "int main() { char x; x = 300; return x / 2; }"
+assert 97 "int main() { char* x; x = \"aaaa\"; return x[0]; }"
+assert 0 "int main() { char* x; x = \"aaaa\"; return x[4]; }"
+assert 101 "int main() { char* x; x = \"aiue\"; return x[3]; }"
+assert 104 "char* sub() { return \"hoge\"; } int main() { char* x; x = sub(); return x[0]; }"
 
 echo OK


### PR DESCRIPTION
# 概要

https://www.sigbus.info/compilerbook#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9725-%E6%96%87%E5%AD%97%E5%88%97%E3%83%AA%E3%83%86%E3%83%A9%E3%83%AB%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%99%E3%82%8B

# 実装

- `char x[10] = "aaaa"`のような文字全てのコピーが必要な文法は不対応（そもそも代入と宣言同時が全部不対応）
- `p2align 2`を全ての関数の冒頭に追加
    - なぜ必要なのか不明だが、これがないと文字列リテラルがうまく動かなかった