### PR TITLE
リファクタ: Nodeの`init`から`sourceToken: `ではなく各Tokenを個別に受け取る

### DIFF
--- a/Sources/Parser/Node/ExpressionNode.swift
+++ b/Sources/Parser/Node/ExpressionNode.swift
@@ -18,7 +18,7 @@ public class InfixOperatorExpressionNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(left: any NodeProtocol, operator: any NodeProtocol, right: any NodeProtocol) {
+    public init(left: any NodeProtocol, operator: any NodeProtocol, right: any NodeProtocol) {
         self.left = left
         self.operator = `operator`
         self.right = right
@@ -61,7 +61,7 @@ public class PrefixOperatorExpressionNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(operator: Token, expression: any NodeProtocol) {
+    public init(operator: Token, expression: any NodeProtocol) {
         self.operator = `operator`
         self.expression = expression
     }
@@ -88,7 +88,7 @@ public class FunctionCallExpressionNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(identifierToken: Token, parenthesisLeftToken: Token, arguments: [any NodeProtocol], parenthesisRightToken: Token) {
+    public init(identifierToken: Token, parenthesisLeftToken: Token, arguments: [any NodeProtocol], parenthesisRightToken: Token) {
         self.identifierToken = identifierToken
         self.parenthesisLeftToken = parenthesisLeftToken
         self.arguments = arguments

--- a/Sources/Parser/Node/ExpressionNode.swift
+++ b/Sources/Parser/Node/ExpressionNode.swift
@@ -4,23 +4,24 @@ public class InfixOperatorExpressionNode: NodeProtocol {
 
     // MARK: - Property
 
-    public var kind: NodeKind = .infixOperatorExpr
+    public let kind: NodeKind = .infixOperatorExpr
+    public var sourceTokens: [Token] {
+        left.sourceTokens + `operator`.sourceTokens + right.sourceTokens
+    }
+    public var children: [any NodeProtocol] {
+        [left, `operator`, right]
+    }
 
-    public var left: any NodeProtocol
-    public var right: any NodeProtocol
-
-    public var `operator`: any NodeProtocol
-
-    public let sourceTokens: [Token]
-    public var children: [any NodeProtocol] { [left, right, `operator`] }
+    public let left: any NodeProtocol
+    public let `operator`: any NodeProtocol
+    public let right: any NodeProtocol
 
     // MARK: - Initializer
 
-    init(operator: any NodeProtocol, left: any NodeProtocol, right: any NodeProtocol, sourceTokens: [Token]) {
-        self.operator = `operator`
+    init(left: any NodeProtocol, operator: any NodeProtocol, right: any NodeProtocol) {
         self.left = left
+        self.operator = `operator`
         self.right = right
-        self.sourceTokens = sourceTokens
     }
 }
 
@@ -36,7 +37,14 @@ public class PrefixOperatorExpressionNode: NodeProtocol {
 
     // MARK: - Property
 
-    public var kind: NodeKind = .prefixOperatorExpr
+    public let kind: NodeKind = .prefixOperatorExpr
+    public var sourceTokens: [Token] {
+        [`operator`] + expression.sourceTokens
+    }
+    public var children: [any NodeProtocol] { [expression] }
+
+    public let `operator`: Token
+    public let expression: any NodeProtocol
 
     public var operatorKind: OperatorKind {
         switch `operator` {
@@ -51,18 +59,11 @@ public class PrefixOperatorExpressionNode: NodeProtocol {
         }
     }
 
-    public let sourceTokens: [Token]
-    public var children: [any NodeProtocol] { [right] }
-    public let `operator`: Token
-
-    public let right: any NodeProtocol
-
     // MARK: - Initializer
 
-    init(operator: Token, right: any NodeProtocol, sourceTokens: [Token]) {
+    init(operator: Token, expression: any NodeProtocol) {
         self.operator = `operator`
-        self.right = right
-        self.sourceTokens = sourceTokens
+        self.expression = expression
     }
 }
 
@@ -70,22 +71,28 @@ public class FunctionCallExpressionNode: NodeProtocol {
 
     // MARK: - Property
 
-    public var kind: NodeKind = .functionCallExpr
-    public let sourceTokens: [Token]
+    public let kind: NodeKind = .functionCallExpr
+    public var sourceTokens: [Token] {
+        [identifierToken, parenthesisLeftToken] + arguments.flatMap { $0.sourceTokens } + [parenthesisRightToken]
+    }
     public var children: [any NodeProtocol] { arguments }
 
-    public let token: Token
+    public let identifierToken: Token
+    public let parenthesisLeftToken: Token
     public let arguments: [any NodeProtocol]
+    public let parenthesisRightToken: Token
+
     public var functionName: String {
-        token.value
+        identifierToken.value
     }
 
     // MARK: - Initializer
 
-    init(token: Token, arguments: [any NodeProtocol], sourceTokens: [Token]) {
-        self.token = token
+    init(identifierToken: Token, parenthesisLeftToken: Token, arguments: [any NodeProtocol], parenthesisRightToken: Token) {
+        self.identifierToken = identifierToken
+        self.parenthesisLeftToken = parenthesisLeftToken
         self.arguments = arguments
-        self.sourceTokens = sourceTokens
+        self.parenthesisRightToken = parenthesisRightToken
     }
 }
 
@@ -93,9 +100,9 @@ public class SubscriptCallExpressionNode: NodeProtocol {
 
     // MARK: - Property
 
-    public var kind: NodeKind = .subscriptCallExpr
+    public let kind: NodeKind = .subscriptCallExpr
     public var sourceTokens: [Token] { identifierNode.sourceTokens + [squareLeftToken] + argument.sourceTokens + [squareRightToken] }
-    public var children: [any NodeProtocol] { [argument] }
+    public var children: [any NodeProtocol] { [identifierNode, argument] }
 
     public let identifierNode: IdentifierNode
     public let squareLeftToken: Token
@@ -117,8 +124,8 @@ public class ArrayExpressionNode: NodeProtocol {
     // MARK: - Property
 
     public var kind: NodeKind = .arrayExpr
-    public var children: [any NodeProtocol] { return exprListNodes.flatMap { $0.children } }
     public var sourceTokens: [Token] { return  [braceLeft] + exprListNodes.flatMap { $0.sourceTokens } + [braceRight] }
+    public var children: [any NodeProtocol] { return exprListNodes.flatMap { $0.children } }
 
     public let braceLeft: Token
     public let exprListNodes: [any NodeProtocol]

--- a/Sources/Parser/Node/Node.swift
+++ b/Sources/Parser/Node/Node.swift
@@ -32,9 +32,9 @@ public enum NodeKind {
 }
 
 public protocol NodeProtocol: Equatable {
+    var kind: NodeKind { get }
     var sourceTokens: [Token] { get }
     var children: [any NodeProtocol] { get }
-    var kind: NodeKind { get }
 }
 
 extension NodeProtocol {
@@ -45,9 +45,9 @@ extension NodeProtocol {
 
 public final class AnyNode: NodeProtocol {
 
+    public let kind: NodeKind
     public let sourceTokens: [Token]
     public let children: [any NodeProtocol]
-    public let kind: NodeKind
 
     init(_ node: any NodeProtocol) {
         self.sourceTokens = node.sourceTokens
@@ -62,175 +62,5 @@ public final class AnyNode: NodeProtocol {
         && zip(lhs.children, rhs.children).allSatisfy { lhsChild, rhsChild in
             AnyNode(lhsChild) == AnyNode(rhsChild)
         }
-    }
-}
-
-public class IntegerLiteralNode: NodeProtocol {
-
-    // MARK: - Property
-
-    public let kind: NodeKind = .integerLiteral
-
-    public let sourceTokens: [Token]
-    public let children: [any NodeProtocol] = []
-    public var token: Token
-
-    public var literal: String {
-        token.value
-    }
-
-    // MARK: - Initializer
-
-    init(token: Token) {
-        self.token = token
-        self.sourceTokens = [token]
-    }
-}
-
-public class StringLiteralNode: NodeProtocol {
-
-    // MARK: - Property
-
-    public let kind: NodeKind = .stringLiteral
-
-    public let sourceTokens: [Token]
-    public let children: [any NodeProtocol] = []
-    public var token: Token
-
-    public var value: String {
-        token.value
-    }
-
-    // MARK: - Initializer
-
-    init(token: Token) {
-        self.token = token
-        self.sourceTokens = [token]
-    }
-}
-
-public class IdentifierNode: NodeProtocol {
-
-    // MARK: - Property
-
-    public var kind: NodeKind = .identifier
-
-    public let sourceTokens: [Token]
-    public let children: [any NodeProtocol] = []
-    public var token: Token
-
-    public var identifierName: String {
-        token.value
-    }
-
-    // MARK: - Initializer
-
-    init(token: Token) {
-        self.token = token
-        self.sourceTokens = [token]
-    }
-}
-
-public class BinaryOperatorNode: NodeProtocol {
-
-    public enum OperatorKind {
-        /// `+`
-        case add
-
-        /// `-`
-        case sub
-
-        /// `*`
-        case mul
-
-        /// `/`
-        case div
-
-        /// `==`
-        case equal
-
-        /// `!=`
-        case notEqual
-
-        /// `<`
-        case lessThan
-
-        /// `<=`
-        case lessThanOrEqual
-
-        /// `>`
-        case greaterThan
-
-        /// `>=`
-        case greaterThanOrEqual
-    }
-
-    // MARK: - Property
-
-    public var kind: NodeKind = .binaryOperator
-
-    public var operatorKind: OperatorKind {
-        switch token {
-        case .reserved(.add, _):
-            return .add
-
-        case .reserved(.sub, _):
-            return .sub
-
-        case .reserved(.mul, _):
-            return .mul
-
-        case .reserved(.div, _):
-            return .div
-
-        case .reserved(.equal, _):
-            return .equal
-
-        case .reserved(.notEqual, _):
-            return .notEqual
-
-        case .reserved(.lessThan, _):
-            return .lessThan
-
-        case .reserved(.lessThanOrEqual, _):
-            return .lessThanOrEqual
-
-        case .reserved(.greaterThan, _):
-            return .greaterThan
-
-        case .reserved(.greaterThanOrEqual, _):
-            return .greaterThanOrEqual
-
-        default:
-            fatalError()
-        }
-    }
-    public let sourceTokens: [Token]
-    public let children: [any NodeProtocol] = []
-    public var token: Token
-
-    // MARK: - Initializer
-
-    init(token: Token) {
-        self.token = token
-        self.sourceTokens = [token]
-    }
-}
-
-public class AssignNode: NodeProtocol {
-
-    // MARK: - Property
-
-    public var kind: NodeKind = .assign
-
-    public let sourceTokens: [Token]
-    public let children: [any NodeProtocol] = []
-    public var token: Token
-
-    // MARK: - Initializer
-
-    init(token: Token) {
-        self.token = token
-        self.sourceTokens = [token]
     }
 }

--- a/Sources/Parser/Node/Node.swift
+++ b/Sources/Parser/Node/Node.swift
@@ -49,7 +49,7 @@ public final class AnyNode: NodeProtocol {
     public let sourceTokens: [Token]
     public let children: [any NodeProtocol]
 
-    init(_ node: any NodeProtocol) {
+    public init(_ node: any NodeProtocol) {
         self.sourceTokens = node.sourceTokens
         self.children = node.children
         self.kind = node.kind

--- a/Sources/Parser/Node/Node.swift
+++ b/Sources/Parser/Node/Node.swift
@@ -17,12 +17,15 @@ public enum NodeKind {
     case functionCallExpr
     case subscriptCallExpr
     case arrayExpr
+    case exprListItem
+    case tupleExpr
 
     case ifStatement
     case whileStatement
     case forStatement
     case returnStatement
     case blockStatement
+    case blockItem
 
     case functionDecl
     case functionParameter

--- a/Sources/Parser/Node/PrimaryNode.swift
+++ b/Sources/Parser/Node/PrimaryNode.swift
@@ -1,0 +1,176 @@
+import Tokenizer
+
+public class IntegerLiteralNode: NodeProtocol {
+
+    // MARK: - Property
+
+    public let kind: NodeKind = .integerLiteral
+
+    public var sourceTokens: [Token] {
+        [token]
+    }
+    public let children: [any NodeProtocol] = []
+    public let token: Token
+
+    public var literal: String {
+        token.value
+    }
+
+    // MARK: - Initializer
+
+    init(token: Token) {
+        self.token = token
+    }
+}
+
+public class StringLiteralNode: NodeProtocol {
+
+    // MARK: - Property
+
+    public let kind: NodeKind = .stringLiteral
+    public var sourceTokens: [Token] {
+        [token]
+    }
+    public let children: [any NodeProtocol] = []
+
+    public let token: Token
+
+    public var value: String {
+        token.value
+    }
+
+    // MARK: - Initializer
+
+    init(token: Token) {
+        self.token = token
+    }
+}
+
+public class IdentifierNode: NodeProtocol {
+
+    // MARK: - Property
+
+    public let kind: NodeKind = .identifier
+
+    public var sourceTokens: [Token] {
+        [token]
+    }
+    public let children: [any NodeProtocol] = []
+    public let token: Token
+
+    public var identifierName: String {
+        token.value
+    }
+
+    // MARK: - Initializer
+
+    init(token: Token) {
+        self.token = token
+    }
+}
+
+public class BinaryOperatorNode: NodeProtocol {
+
+    public enum OperatorKind {
+        /// `+`
+        case add
+
+        /// `-`
+        case sub
+
+        /// `*`
+        case mul
+
+        /// `/`
+        case div
+
+        /// `==`
+        case equal
+
+        /// `!=`
+        case notEqual
+
+        /// `<`
+        case lessThan
+
+        /// `<=`
+        case lessThanOrEqual
+
+        /// `>`
+        case greaterThan
+
+        /// `>=`
+        case greaterThanOrEqual
+    }
+
+    // MARK: - Property
+
+    public let kind: NodeKind = .binaryOperator
+
+    public var operatorKind: OperatorKind {
+        switch token {
+        case .reserved(.add, _):
+            return .add
+
+        case .reserved(.sub, _):
+            return .sub
+
+        case .reserved(.mul, _):
+            return .mul
+
+        case .reserved(.div, _):
+            return .div
+
+        case .reserved(.equal, _):
+            return .equal
+
+        case .reserved(.notEqual, _):
+            return .notEqual
+
+        case .reserved(.lessThan, _):
+            return .lessThan
+
+        case .reserved(.lessThanOrEqual, _):
+            return .lessThanOrEqual
+
+        case .reserved(.greaterThan, _):
+            return .greaterThan
+
+        case .reserved(.greaterThanOrEqual, _):
+            return .greaterThanOrEqual
+
+        default:
+            fatalError()
+        }
+    }
+    public var sourceTokens: [Token] {
+        [token]
+    }
+    public let children: [any NodeProtocol] = []
+    public let token: Token
+
+    // MARK: - Initializer
+
+    init(token: Token) {
+        self.token = token
+    }
+}
+
+public class AssignNode: NodeProtocol {
+
+    // MARK: - Property
+
+    public let kind: NodeKind = .assign
+
+    public var sourceTokens: [Token] {
+        [token]
+    }
+    public let children: [any NodeProtocol] = []
+    public let token: Token
+
+    // MARK: - Initializer
+
+    init(token: Token) {
+        self.token = token
+    }
+}

--- a/Sources/Parser/Node/PrimaryNode.swift
+++ b/Sources/Parser/Node/PrimaryNode.swift
@@ -18,7 +18,7 @@ public class IntegerLiteralNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(token: Token) {
+    public init(token: Token) {
         self.token = token
     }
 }
@@ -41,7 +41,7 @@ public class StringLiteralNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(token: Token) {
+    public init(token: Token) {
         self.token = token
     }
 }
@@ -64,7 +64,7 @@ public class IdentifierNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(token: Token) {
+    public init(token: Token) {
         self.token = token
     }
 }
@@ -151,7 +151,7 @@ public class BinaryOperatorNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(token: Token) {
+    public init(token: Token) {
         self.token = token
     }
 }
@@ -170,7 +170,7 @@ public class AssignNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(token: Token) {
+    public init(token: Token) {
         self.token = token
     }
 }

--- a/Sources/Parser/Node/StatementNode.swift
+++ b/Sources/Parser/Node/StatementNode.swift
@@ -2,109 +2,105 @@ import Tokenizer
 
 public class WhileStatementNode: NodeProtocol {
 
-    public var kind: NodeKind = .whileStatement
+    // MARK: - Property
 
-    public let token: Token
-    public let sourceTokens: [Token]
+    public var kind: NodeKind = .whileStatement
+    public var sourceTokens: [Token] {
+        [whileToken] + condition.sourceTokens + body.sourceTokens
+    }
     public var children: [any NodeProtocol] { [condition, body] }
 
-    public var condition: any NodeProtocol
-    public var body: any NodeProtocol
+    public let whileToken: Token
+    public let condition: any NodeProtocol
+    public let body: any NodeProtocol
 
-    init(token: Token, condition: any NodeProtocol, body: any NodeProtocol, sourceTokens: [Token]) {
-        self.token = token
+    // MARK: - Initializer
+
+    init(whileToken: Token, condition: any NodeProtocol, body: any NodeProtocol) {
+        self.whileToken = whileToken
         self.condition = condition
         self.body = body
-        self.sourceTokens = sourceTokens
     }
 }
 
 public class ForStatementNode: NodeProtocol {
 
-    public var kind: NodeKind = .forStatement
+    // MARK: - Property
 
-    public let token: Token
+    public let kind: NodeKind = .forStatement
+    public var sourceTokens: [Token] {
+        [forToken] + (pre?.sourceTokens ?? []) + (condition?.sourceTokens ?? []) + (post?.sourceTokens ?? [])
+    }
+    public var children: [any NodeProtocol] {
+        [pre, condition, post, body].compactMap { $0 }
+    }
 
-    public var condition: (any NodeProtocol)?
+    public let forToken: Token
     public var pre: (any NodeProtocol)?
+    public var condition: (any NodeProtocol)?
     public var post: (any NodeProtocol)?
     public var body: any NodeProtocol
 
-    public let sourceTokens: [Token]
-    public var children: [any NodeProtocol] {
-        var result: [any NodeProtocol] = [body]
+    // MARK: - Initializer
 
-        if let pre {
-            result.append(pre)
-        }
-
-        if let post {
-            result.append(post)
-        }
-
-        if let condition {
-            result.append(condition)
-        }
-
-        return result
-    }
-
-    init(token: Token, condition: (any NodeProtocol)?, pre: (any NodeProtocol)?, post: (any NodeProtocol)?, body: any NodeProtocol, sourceTokens: [Token]) {
-        self.token = token
+    init(forToken: Token, pre: (any NodeProtocol)?, condition: (any NodeProtocol)?, post: (any NodeProtocol)?, body: any NodeProtocol) {
+        self.forToken = forToken
         self.condition = condition
         self.pre = pre
         self.post = post
         self.body = body
-        self.sourceTokens = sourceTokens
     }
 }
 
 public class IfStatementNode: NodeProtocol {
 
-    public var kind: NodeKind = .ifStatement
+    // MARK: - Property
 
-    public let ifToken: Token
-    public let elseToken: Token?
+    public let kind: NodeKind = .ifStatement
+    public var sourceTokens: [Token] {
+        var result = [ifToken] + condition.sourceTokens + trueBody.sourceTokens
 
-    public var condition: any NodeProtocol
-    public var trueBody: any NodeProtocol
-    public var falseBody: (any NodeProtocol)?
-
-    public let sourceTokens: [Token]
-    public var children: [any NodeProtocol] {
-        var result: [any NodeProtocol] = [condition, trueBody]
-
-        if let falseBody {
-            result.append(falseBody)
+        if let elseToken {
+            result.append(elseToken)
         }
 
-        return result
+        return result + (falseBody?.sourceTokens ?? [])
+    }
+    public var children: [any NodeProtocol] {
+        [condition, trueBody, falseBody].compactMap { $0 }
     }
 
-    init(ifToken: Token, condition: any NodeProtocol, trueBody: any NodeProtocol, elseToken: Token?, falseBody: (any NodeProtocol)?, sourceTokens: [Token]) {
+    public let ifToken: Token
+    public let condition: any NodeProtocol
+    public let trueBody: any NodeProtocol
+    public let elseToken: Token?
+    public let falseBody: (any NodeProtocol)?
+
+    init(ifToken: Token, condition: any NodeProtocol, trueBody: any NodeProtocol, elseToken: Token?, falseBody: (any NodeProtocol)?) {
         self.ifToken = ifToken
         self.condition = condition
         self.trueBody = trueBody
         self.elseToken = elseToken
         self.falseBody = falseBody
-        self.sourceTokens = sourceTokens
     }
 }
 
 public class ReturnStatementNode: NodeProtocol {
 
-    public var kind: NodeKind = .returnStatement
-    public let token: Token
+    // MARK: - Property
 
-    public var expression: any NodeProtocol
-
-    public let sourceTokens: [Token]
+    public let kind: NodeKind = .returnStatement
+    public var sourceTokens: [Token] { [returnToken] + expression.sourceTokens }
     public var children: [any NodeProtocol] { [expression] }
 
-    init(token: Token, expression: any NodeProtocol, sourceTokens: [Token]) {
-        self.token = token
+    public let returnToken: Token
+    public let expression: any NodeProtocol
+
+    // MARK: - Initializer
+
+    init(returnToken: Token, expression: any NodeProtocol) {
+        self.returnToken = returnToken
         self.expression = expression
-        self.sourceTokens = sourceTokens
     }
 }
 
@@ -113,16 +109,17 @@ public class BlockStatementNode: NodeProtocol {
     // MARK: - Property
 
     public var kind: NodeKind = .blockStatement
-    public let sourceTokens: [Token]
+    public var sourceTokens: [Token] {
+        statements.flatMap { $0.sourceTokens }
+    }
     public var children: [any NodeProtocol] { statements }
 
-    public var statements: [any NodeProtocol]
+    public let statements: [any NodeProtocol]
 
     // MARK: - Initializer
 
-    init(statements: [any NodeProtocol], sourceTokens: [Token]) {
+    init(statements: [any NodeProtocol]) {
         self.statements = statements
-        self.sourceTokens = sourceTokens
     }
 }
 
@@ -130,7 +127,7 @@ public class FunctionDeclNode: NodeProtocol {
 
     // MARK: - Property
 
-    public var kind: NodeKind = .functionDecl
+    public let kind: NodeKind = .functionDecl
     public var sourceTokens: [Token] {
         returnTypeNode.sourceTokens +
         [functionNameToken, parenthesisLeftToken] +
@@ -189,13 +186,7 @@ public class VariableDeclNode: NodeProtocol {
         return tokens
     }
     public var children: [any NodeProtocol] {
-        var nodes: [any NodeProtocol] = [type]
-
-        if let initializerExpr {
-            nodes += [initializerExpr]
-        }
-
-        return nodes
+        [type, initializerExpr].compactMap { $0 }
     }
 
     public let type: any TypeNodeProtocol

--- a/Sources/Parser/Node/StatementNode.swift
+++ b/Sources/Parser/Node/StatementNode.swift
@@ -16,7 +16,7 @@ public class WhileStatementNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(whileToken: Token, condition: any NodeProtocol, body: any NodeProtocol) {
+    public init(whileToken: Token, condition: any NodeProtocol, body: any NodeProtocol) {
         self.whileToken = whileToken
         self.condition = condition
         self.body = body
@@ -43,7 +43,7 @@ public class ForStatementNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(forToken: Token, pre: (any NodeProtocol)?, condition: (any NodeProtocol)?, post: (any NodeProtocol)?, body: any NodeProtocol) {
+    public init(forToken: Token, pre: (any NodeProtocol)?, condition: (any NodeProtocol)?, post: (any NodeProtocol)?, body: any NodeProtocol) {
         self.forToken = forToken
         self.condition = condition
         self.pre = pre
@@ -76,7 +76,7 @@ public class IfStatementNode: NodeProtocol {
     public let elseToken: Token?
     public let falseBody: (any NodeProtocol)?
 
-    init(ifToken: Token, condition: any NodeProtocol, trueBody: any NodeProtocol, elseToken: Token?, falseBody: (any NodeProtocol)?) {
+    public init(ifToken: Token, condition: any NodeProtocol, trueBody: any NodeProtocol, elseToken: Token?, falseBody: (any NodeProtocol)?) {
         self.ifToken = ifToken
         self.condition = condition
         self.trueBody = trueBody
@@ -98,7 +98,7 @@ public class ReturnStatementNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(returnToken: Token, expression: any NodeProtocol) {
+    public init(returnToken: Token, expression: any NodeProtocol) {
         self.returnToken = returnToken
         self.expression = expression
     }
@@ -118,7 +118,7 @@ public class BlockStatementNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(statements: [any NodeProtocol]) {
+    public init(statements: [any NodeProtocol]) {
         self.statements = statements
     }
 }
@@ -150,7 +150,7 @@ public class FunctionDeclNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(
+    public init(
         returnTypeNode: any NodeProtocol,
         functionNameToken: Token,
         parenthesisLeftToken: Token,
@@ -200,7 +200,7 @@ public class VariableDeclNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(type: any TypeNodeProtocol, identifierToken: Token, initializerToken: Token? = nil, initializerExpr: (any NodeProtocol)? = nil) {
+    public init(type: any TypeNodeProtocol, identifierToken: Token, initializerToken: Token? = nil, initializerExpr: (any NodeProtocol)? = nil) {
         self.type = type
         self.identifierToken = identifierToken
         self.initializerToken = initializerToken
@@ -227,7 +227,7 @@ public class FunctionParameterNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(type: any TypeNodeProtocol, identifierToken: Token) {
+    public init(type: any TypeNodeProtocol, identifierToken: Token) {
         self.type = type
         self.identifierToken = identifierToken
     }
@@ -251,7 +251,7 @@ public class SourceFileNode: NodeProtocol {
 
     // MARK: - Initializer
 
-    init(functions: [FunctionDeclNode], globalVariables: [VariableDeclNode]) {
+    public init(functions: [FunctionDeclNode], globalVariables: [VariableDeclNode]) {
         self.functions = functions
         self.globalVariables = globalVariables
     }

--- a/Sources/Parser/Node/TypeNode.swift
+++ b/Sources/Parser/Node/TypeNode.swift
@@ -50,7 +50,7 @@ public class PointerTypeNode: TypeNodeProtocol {
 
     // MARK: - Initializer
 
-    init(referenceType: any TypeNodeProtocol, pointerToken: Token) {
+    public init(referenceType: any TypeNodeProtocol, pointerToken: Token) {
         self.referenceType = referenceType
         self.pointerToken = pointerToken
     }

--- a/Sources/Parser/Node/TypeNode.swift
+++ b/Sources/Parser/Node/TypeNode.swift
@@ -60,7 +60,7 @@ public class ArrayTypeNode: TypeNodeProtocol {
 
     // MARK: - Property
 
-    public var kind: NodeKind = .arrayType
+    public let kind: NodeKind = .arrayType
 
     public var sourceTokens: [Token] { [squareLeftToken] + elementType.sourceTokens + [squareRightToken] }
     public var children: [any NodeProtocol] { [elementType] }

--- a/Tests/ParserTest/AssignTest.swift
+++ b/Tests/ParserTest/AssignTest.swift
@@ -16,10 +16,9 @@ final class AssignTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
+                left: IdentifierNode(token: tokens[0]), 
                 operator: AssignNode(token: tokens[1]),
-                left: IdentifierNode(token: tokens[0]),
-                right: IntegerLiteralNode(token: tokens[2]), 
-                sourceTokens: Array(tokens[0...2])
+                right: IntegerLiteralNode(token: tokens[2])
             )
         )
     }
@@ -38,15 +37,13 @@ final class AssignTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
+                left: IdentifierNode(token: tokens[0]), 
                 operator: AssignNode(token: tokens[1]),
-                left: IdentifierNode(token: tokens[0]),
                 right: InfixOperatorExpressionNode(
-                    operator: AssignNode(token: tokens[3]),
                     left: IdentifierNode(token: tokens[2]),
-                    right: IntegerLiteralNode(token: tokens[4]), 
-                    sourceTokens: Array(tokens[2...4])
-                ),
-                sourceTokens: Array(tokens[0...4])
+                    operator: AssignNode(token: tokens[3]),
+                    right: IntegerLiteralNode(token: tokens[4])
+                )
             )
         )
     }
@@ -64,10 +61,9 @@ final class AssignTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
+                left: IntegerLiteralNode(token: tokens[0]), 
                 operator: AssignNode(token: tokens[1]),
-                left: IntegerLiteralNode(token: tokens[0]),
-                right: IntegerLiteralNode(token: tokens[2]),
-                sourceTokens: Array(tokens[0...2])
+                right: IntegerLiteralNode(token: tokens[2])
             )
         )
     }

--- a/Tests/ParserTest/AssignTest.swift
+++ b/Tests/ParserTest/AssignTest.swift
@@ -13,12 +13,17 @@ final class AssignTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IdentifierNode(token: tokens[0]), 
-                operator: AssignNode(token: tokens[1]),
-                right: IntegerLiteralNode(token: tokens[2])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IdentifierNode(token: tokens[0]),
+                    operator: AssignNode(token: tokens[1]),
+                    right: IntegerLiteralNode(token: tokens[2])
+                ),
+                semicolonToken: tokens[3]
             )
         )
     }
@@ -34,16 +39,21 @@ final class AssignTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IdentifierNode(token: tokens[0]), 
-                operator: AssignNode(token: tokens[1]),
-                right: InfixOperatorExpressionNode(
-                    left: IdentifierNode(token: tokens[2]),
-                    operator: AssignNode(token: tokens[3]),
-                    right: IntegerLiteralNode(token: tokens[4])
-                )
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IdentifierNode(token: tokens[0]),
+                    operator: AssignNode(token: tokens[1]),
+                    right: InfixOperatorExpressionNode(
+                        left: IdentifierNode(token: tokens[2]),
+                        operator: AssignNode(token: tokens[3]),
+                        right: IntegerLiteralNode(token: tokens[4])
+                    )
+                ),
+                semicolonToken: tokens[5]
             )
         )
     }
@@ -58,12 +68,17 @@ final class AssignTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IntegerLiteralNode(token: tokens[0]), 
-                operator: AssignNode(token: tokens[1]),
-                right: IntegerLiteralNode(token: tokens[2])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    operator: AssignNode(token: tokens[1]),
+                    right: IntegerLiteralNode(token: tokens[2])
+                ),
+                semicolonToken: tokens[3]
             )
         )
     }

--- a/Tests/ParserTest/Control/ForTest.swift
+++ b/Tests/ParserTest/Control/ForTest.swift
@@ -19,14 +19,25 @@ final class ForTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! ForStatementNode,
-            ForStatementNode(
-                forToken: tokens[0],
-                pre: IntegerLiteralNode(token: tokens[2]), 
-                condition: IntegerLiteralNode(token: tokens[4]),
-                post: IntegerLiteralNode(token: tokens[6]),
-                body: IntegerLiteralNode(token: tokens[8])
+            node,
+            BlockItemNode(
+                item: ForStatementNode(
+                    forToken: tokens[0],
+                    parenthesisLeftToken: tokens[1],
+                    pre: IntegerLiteralNode(token: tokens[2]),
+                    firstSemicolonToken: tokens[3],
+                    condition: IntegerLiteralNode(token: tokens[4]),
+                    secondSemicolonToken: tokens[5],
+                    post: IntegerLiteralNode(token: tokens[6]),
+                    parenthesisRightToken: tokens[7],
+                    body: BlockItemNode(
+                        item: IntegerLiteralNode(token: tokens[8]),
+                        semicolonToken: tokens[9]
+                    )
+                )
             )
         )
     }
@@ -50,18 +61,30 @@ final class ForTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! ForStatementNode,
-            ForStatementNode(
-                forToken: tokens[0],
-                pre: IntegerLiteralNode(token: tokens[2]),
-                condition: IntegerLiteralNode(token: tokens[4]),
-                post: IntegerLiteralNode(token: tokens[6]),
-                body: BlockStatementNode(
-                    statements: [
-                        IntegerLiteralNode(token: tokens[9]),
-                        IntegerLiteralNode(token: tokens[11]),
-                    ]
+            node,
+            BlockItemNode(
+                item: ForStatementNode(
+                    forToken: tokens[0],
+                    parenthesisLeftToken: tokens[1],
+                    pre: IntegerLiteralNode(token: tokens[2]),
+                    firstSemicolonToken: tokens[3],
+                    condition: IntegerLiteralNode(token: tokens[4]),
+                    secondSemicolonToken: tokens[5],
+                    post: IntegerLiteralNode(token: tokens[6]),
+                    parenthesisRightToken: tokens[7],
+                    body: BlockItemNode(
+                        item: BlockStatementNode(
+                            braceLeftToken: tokens[8],
+                            items: [
+                                BlockItemNode(item: IntegerLiteralNode(token: tokens[9]), semicolonToken: tokens[10]),
+                                BlockItemNode(item: IntegerLiteralNode(token: tokens[11]), semicolonToken: tokens[12])
+                            ],
+                            braceRightToken: tokens[13]
+                        )
+                    )
                 )
             )
         )
@@ -79,14 +102,25 @@ final class ForTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! ForStatementNode,
-            ForStatementNode(
-                forToken: tokens[0],
-                pre: nil, 
-                condition: nil,
-                post: nil,
-                body: IntegerLiteralNode(token: tokens[5])
+            node,
+            BlockItemNode(
+                item: ForStatementNode(
+                    forToken: tokens[0],
+                    parenthesisLeftToken: tokens[1],
+                    pre: nil,
+                    firstSemicolonToken: tokens[2],
+                    condition: nil,
+                    secondSemicolonToken: tokens[3],
+                    post: nil,
+                    parenthesisRightToken: tokens[4],
+                    body: BlockItemNode(
+                        item: IntegerLiteralNode(token: tokens[5]),
+                        semicolonToken: tokens[6]
+                    )
+                )
             )
         )
     }

--- a/Tests/ParserTest/Control/ForTest.swift
+++ b/Tests/ParserTest/Control/ForTest.swift
@@ -22,12 +22,11 @@ final class ForTest: XCTestCase {
         XCTAssertEqual(
             node as! ForStatementNode,
             ForStatementNode(
-                token: tokens[0],
+                forToken: tokens[0],
+                pre: IntegerLiteralNode(token: tokens[2]), 
                 condition: IntegerLiteralNode(token: tokens[4]),
-                pre: IntegerLiteralNode(token: tokens[2]),
                 post: IntegerLiteralNode(token: tokens[6]),
-                body: IntegerLiteralNode(token: tokens[8]),
-                sourceTokens: Array(tokens[0...9])
+                body: IntegerLiteralNode(token: tokens[8])
             )
         )
     }
@@ -54,18 +53,16 @@ final class ForTest: XCTestCase {
         XCTAssertEqual(
             node as! ForStatementNode,
             ForStatementNode(
-                token: tokens[0],
-                condition: IntegerLiteralNode(token: tokens[4]),
+                forToken: tokens[0],
                 pre: IntegerLiteralNode(token: tokens[2]),
+                condition: IntegerLiteralNode(token: tokens[4]),
                 post: IntegerLiteralNode(token: tokens[6]),
                 body: BlockStatementNode(
                     statements: [
                         IntegerLiteralNode(token: tokens[9]),
                         IntegerLiteralNode(token: tokens[11]),
-                    ],
-                    sourceTokens: Array(tokens[8...13])
-                ),
-                sourceTokens: tokens
+                    ]
+                )
             )
         )
     }
@@ -85,12 +82,11 @@ final class ForTest: XCTestCase {
         XCTAssertEqual(
             node as! ForStatementNode,
             ForStatementNode(
-                token: tokens[0],
+                forToken: tokens[0],
+                pre: nil, 
                 condition: nil,
-                pre: nil,
                 post: nil,
-                body: IntegerLiteralNode(token: tokens[5]),
-                sourceTokens: Array(tokens[0...6])
+                body: IntegerLiteralNode(token: tokens[5])
             )
         )
     }

--- a/Tests/ParserTest/Control/IfTest.swift
+++ b/Tests/ParserTest/Control/IfTest.swift
@@ -22,8 +22,7 @@ final class IfTest: XCTestCase {
                 condition: IntegerLiteralNode(token: tokens[2]),
                 trueBody: IntegerLiteralNode(token: tokens[4]),
                 elseToken: nil,
-                falseBody: nil,
-                sourceTokens: Array(tokens[0...5])
+                falseBody: nil
             )
         )
     }
@@ -49,8 +48,7 @@ final class IfTest: XCTestCase {
                 condition: IntegerLiteralNode(token: tokens[2]),
                 trueBody: IntegerLiteralNode(token: tokens[4]),
                 elseToken: tokens[6],
-                falseBody: IntegerLiteralNode(token: tokens[7]),
-                sourceTokens: Array(tokens[0...8])
+                falseBody: IntegerLiteralNode(token: tokens[7])
             )
         )
     }

--- a/Tests/ParserTest/Control/IfTest.swift
+++ b/Tests/ParserTest/Control/IfTest.swift
@@ -15,14 +15,23 @@ final class IfTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! IfStatementNode,
-            IfStatementNode(
-                ifToken: tokens[0],
-                condition: IntegerLiteralNode(token: tokens[2]),
-                trueBody: IntegerLiteralNode(token: tokens[4]),
-                elseToken: nil,
-                falseBody: nil
+            node,
+            BlockItemNode(
+                item: IfStatementNode(
+                    ifToken: tokens[0],
+                    parenthesisLeftToken: tokens[1],
+                    condition: IntegerLiteralNode(token: tokens[2]),
+                    parenthesisRightToken: tokens[3],
+                    trueBody: BlockItemNode(
+                        item: IntegerLiteralNode(token: tokens[4]),
+                        semicolonToken: tokens[5]
+                    ),
+                    elseToken: nil,
+                    falseBody: nil
+                )
             )
         )
     }
@@ -41,14 +50,26 @@ final class IfTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! IfStatementNode,
-            IfStatementNode(
-                ifToken: tokens[0],
-                condition: IntegerLiteralNode(token: tokens[2]),
-                trueBody: IntegerLiteralNode(token: tokens[4]),
-                elseToken: tokens[6],
-                falseBody: IntegerLiteralNode(token: tokens[7])
+            node,
+            BlockItemNode(
+                item: IfStatementNode(
+                    ifToken: tokens[0],
+                    parenthesisLeftToken: tokens[1],
+                    condition: IntegerLiteralNode(token: tokens[2]),
+                    parenthesisRightToken: tokens[3],
+                    trueBody: BlockItemNode(
+                        item: IntegerLiteralNode(token: tokens[4]),
+                        semicolonToken: tokens[5]
+                    ),
+                    elseToken: tokens[6],
+                    falseBody: BlockItemNode(
+                        item: IntegerLiteralNode(token: tokens[7]),
+                        semicolonToken: tokens[8]
+                    )
+                )
             )
         )
     }

--- a/Tests/ParserTest/Control/WhileTest.swift
+++ b/Tests/ParserTest/Control/WhileTest.swift
@@ -18,10 +18,9 @@ final class WhileTest: XCTestCase {
         XCTAssertEqual(
             node as! WhileStatementNode,
             WhileStatementNode(
-                token: tokens[0],
+                whileToken: tokens[0],
                 condition: IntegerLiteralNode(token: tokens[2]),
-                body: IntegerLiteralNode(token: tokens[4]),
-                sourceTokens: Array(tokens[0...5])
+                body: IntegerLiteralNode(token: tokens[4])
             )
         )
     }

--- a/Tests/ParserTest/Control/WhileTest.swift
+++ b/Tests/ParserTest/Control/WhileTest.swift
@@ -15,12 +15,21 @@ final class WhileTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! WhileStatementNode,
-            WhileStatementNode(
-                whileToken: tokens[0],
-                condition: IntegerLiteralNode(token: tokens[2]),
-                body: IntegerLiteralNode(token: tokens[4])
+            node,
+            BlockItemNode(
+                item: WhileStatementNode(
+                    whileToken: tokens[0],
+                    parenthesisLeftToken: tokens[1],
+                    condition: IntegerLiteralNode(token: tokens[2]),
+                    parenthesisRightToken: tokens[3],
+                    body: BlockItemNode(
+                        item: IntegerLiteralNode(token: tokens[4]),
+                        semicolonToken: tokens[5]
+                    )
+                )
             )
         )
     }

--- a/Tests/ParserTest/FunctionTest.swift
+++ b/Tests/ParserTest/FunctionTest.swift
@@ -19,25 +19,30 @@ final class FunctionTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).parse()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
             node,
             SourceFileNode(
-                functions: [
-                    FunctionDeclNode(
-                        returnTypeNode: TypeNode(typeToken: tokens[0]),
-                        functionNameToken: tokens[1],
-                        parenthesisLeftToken: tokens[2],
-                        parameterNodes: [],
-                        parenthesisRightToken: tokens[3],
-                        block: BlockStatementNode(
-                            statements: [
-                                IntegerLiteralNode(token: tokens[5]),
-                                IntegerLiteralNode(token: tokens[7])
-                            ]
+                statements: [
+                    BlockItemNode(
+                        item: FunctionDeclNode(
+                            returnTypeNode: TypeNode(typeToken: tokens[0]),
+                            functionNameToken: tokens[1],
+                            parenthesisLeftToken: tokens[2],
+                            parameterNodes: [],
+                            parenthesisRightToken: tokens[3],
+                            block: BlockStatementNode(
+                                braceLeftToken: tokens[4],
+                                items: [
+                                    BlockItemNode(item: IntegerLiteralNode(token: tokens[5]), semicolonToken: tokens[6]),
+                                    BlockItemNode(item: IntegerLiteralNode(token: tokens[7]), semicolonToken: tokens[8]),
+                                ],
+                                braceRightToken: tokens[9]
+                            )
                         )
                     )
-                ],
-                globalVariables: []
+                ]
             )
         )
     }
@@ -58,25 +63,30 @@ final class FunctionTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).parse()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
             node,
             SourceFileNode(
-                functions: [
-                    FunctionDeclNode(
-                        returnTypeNode: PointerTypeNode(referenceType: TypeNode(typeToken: tokens[0]), pointerToken: tokens[1]),
-                        functionNameToken: tokens[2],
-                        parenthesisLeftToken: tokens[3],
-                        parameterNodes: [],
-                        parenthesisRightToken: tokens[4],
-                        block: BlockStatementNode(
-                            statements: [
-                                IntegerLiteralNode(token: tokens[6]),
-                                IntegerLiteralNode(token: tokens[8])
-                            ]
+                statements: [
+                    BlockItemNode(
+                        item: FunctionDeclNode(
+                            returnTypeNode: PointerTypeNode(referenceType: TypeNode(typeToken: tokens[0]), pointerToken: tokens[1]),
+                            functionNameToken: tokens[2],
+                            parenthesisLeftToken: tokens[3],
+                            parameterNodes: [],
+                            parenthesisRightToken: tokens[4],
+                            block: BlockStatementNode(
+                                braceLeftToken: tokens[5],
+                                items: [
+                                    BlockItemNode(item: IntegerLiteralNode(token: tokens[6]), semicolonToken: tokens[7]),
+                                    BlockItemNode(item: IntegerLiteralNode(token: tokens[8]), semicolonToken: tokens[9]),
+                                ],
+                                braceRightToken: tokens[10]
+                            )
                         )
                     )
-                ],
-                globalVariables: []
+                ]
             )
         )
     }
@@ -90,13 +100,18 @@ final class FunctionTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! FunctionCallExpressionNode,
-            FunctionCallExpressionNode(
-                identifierToken: tokens[0],
-                parenthesisLeftToken: tokens[1],
-                arguments: [],
-                parenthesisRightToken: tokens[2]
+            node,
+            BlockItemNode(
+                item: FunctionCallExpressionNode(
+                    identifierToken: tokens[0],
+                    parenthesisLeftToken: tokens[1],
+                    arguments: [],
+                    parenthesisRightToken: tokens[2]
+                ),
+                semicolonToken: tokens[3]
             )
         )
     }
@@ -119,27 +134,32 @@ final class FunctionTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).parse()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
             node,
             SourceFileNode(
-                functions: [
-                    FunctionDeclNode(
-                        returnTypeNode: TypeNode(typeToken: tokens[0]),
-                        functionNameToken: tokens[1],
-                        parenthesisLeftToken: tokens[2],
-                        parameterNodes: [
-                            FunctionParameterNode(type: TypeNode(typeToken: tokens[3]), identifierToken: tokens[4]),
-                            FunctionParameterNode(type: TypeNode(typeToken: tokens[6]), identifierToken: tokens[7])
-                        ],
-                        parenthesisRightToken: tokens[8],
-                        block: BlockStatementNode(
-                            statements: [
-                                IntegerLiteralNode(token: tokens[10])
-                            ]
+                statements: [
+                    BlockItemNode(
+                        item: FunctionDeclNode(
+                            returnTypeNode: TypeNode(typeToken: tokens[0]),
+                            functionNameToken: tokens[1],
+                            parenthesisLeftToken: tokens[2],
+                            parameterNodes: [
+                                FunctionParameterNode(type: TypeNode(typeToken: tokens[3]), identifierToken: tokens[4], commaToken: tokens[5]),
+                                FunctionParameterNode(type: TypeNode(typeToken: tokens[6]), identifierToken: tokens[7])
+                            ],
+                            parenthesisRightToken: tokens[8],
+                            block: BlockStatementNode(
+                                braceLeftToken: tokens[9],
+                                items: [
+                                    BlockItemNode(item: IntegerLiteralNode(token: tokens[10]), semicolonToken: tokens[11]),
+                                ],
+                                braceRightToken: tokens[12]
+                            )
                         )
                     )
-                ],
-                globalVariables: []
+                ]
             )
         )
     }
@@ -156,16 +176,24 @@ final class FunctionTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! FunctionCallExpressionNode,
-            FunctionCallExpressionNode(
-                identifierToken: tokens[0],
-                parenthesisLeftToken: tokens[1],
-                arguments: [
-                    IntegerLiteralNode(token: tokens[2]),
-                    IdentifierNode(token: tokens[4])
-                ],
-                parenthesisRightToken: tokens[5]
+            node,
+            BlockItemNode(
+                item: FunctionCallExpressionNode(
+                    identifierToken: tokens[0],
+                    parenthesisLeftToken: tokens[1],
+                    arguments: [
+                        ExpressionListItemNode(
+                            expression: IntegerLiteralNode(token: tokens[2]),
+                            comma: tokens[3]
+                        ),
+                        ExpressionListItemNode(expression: IdentifierNode(token: tokens[4]))
+                    ],
+                    parenthesisRightToken: tokens[5]
+                ),
+                semicolonToken: tokens[6]
             )
         )
     }
@@ -189,38 +217,47 @@ final class FunctionTest: XCTestCase {
             .reserved(.semicolon, sourceIndex: 26),
             .reserved(.braceRight, sourceIndex: 27)
         ]
-        let nodes = try Parser(tokens: tokens).parse()
+        let node = try Parser(tokens: tokens).parse()
+
+        XCTAssertEqual(node.sourceTokens, tokens)
 
         XCTAssertEqual(
-            nodes,
+            node,
             SourceFileNode(
-                functions: [
-                    FunctionDeclNode(
-                        returnTypeNode: TypeNode(typeToken: tokens[0]),
-                        functionNameToken: tokens[1],
-                        parenthesisLeftToken: tokens[2],
-                        parameterNodes: [],
-                        parenthesisRightToken: tokens[3],
-                        block: BlockStatementNode(
-                            statements: [
-                                IntegerLiteralNode(token: tokens[5])
-                            ]
+                statements: [
+                    BlockItemNode(
+                        item: FunctionDeclNode(
+                            returnTypeNode: TypeNode(typeToken: tokens[0]),
+                            functionNameToken: tokens[1],
+                            parenthesisLeftToken: tokens[2],
+                            parameterNodes: [],
+                            parenthesisRightToken: tokens[3],
+                            block: BlockStatementNode(
+                                braceLeftToken: tokens[4],
+                                items: [
+                                    BlockItemNode(item: IntegerLiteralNode(token: tokens[5]), semicolonToken: tokens[6])
+                                ],
+                                braceRightToken: tokens[7]
+                            )
                         )
                     ),
-                    FunctionDeclNode(
-                        returnTypeNode: TypeNode(typeToken: tokens[8]),
-                        functionNameToken: tokens[9],
-                        parenthesisLeftToken: tokens[10],
-                        parameterNodes: [],
-                        parenthesisRightToken: tokens[11],
-                        block: BlockStatementNode(
-                            statements: [
-                                IntegerLiteralNode(token: tokens[13])
-                            ]
+                    BlockItemNode(
+                        item: FunctionDeclNode(
+                            returnTypeNode: TypeNode(typeToken: tokens[8]),
+                            functionNameToken: tokens[9],
+                            parenthesisLeftToken: tokens[10],
+                            parameterNodes: [],
+                            parenthesisRightToken: tokens[11],
+                            block: BlockStatementNode(
+                                braceLeftToken: tokens[12],
+                                items: [
+                                    BlockItemNode(item: IntegerLiteralNode(token: tokens[13]), semicolonToken: tokens[14])
+                                ],
+                                braceRightToken: tokens[15]
+                            )
                         )
                     )
-                ],
-                globalVariables: []
+                ]
             )
         )
     }
@@ -235,13 +272,18 @@ final class FunctionTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! SubscriptCallExpressionNode,
-            SubscriptCallExpressionNode(
-                identifierNode: IdentifierNode(token: tokens[0]),
-                squareLeftToken: tokens[1],
-                argument: IntegerLiteralNode(token: tokens[2]),
-                squareRightToken: tokens[3]
+            node,
+            BlockItemNode(
+                item: SubscriptCallExpressionNode(
+                    identifierNode: IdentifierNode(token: tokens[0]),
+                    squareLeftToken: tokens[1],
+                    argument: IntegerLiteralNode(token: tokens[2]),
+                    squareRightToken: tokens[3]
+                ),
+                semicolonToken: tokens[4]
             )
         )
     }
@@ -258,17 +300,22 @@ final class FunctionTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! SubscriptCallExpressionNode,
-            SubscriptCallExpressionNode(
-                identifierNode: IdentifierNode(token: tokens[0]),
-                squareLeftToken: tokens[1],
-                argument: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[2]),
-                    operator: BinaryOperatorNode(token: tokens[3]),
-                    right: IdentifierNode(token: tokens[4])
+            node,
+            BlockItemNode(
+                item: SubscriptCallExpressionNode(
+                    identifierNode: IdentifierNode(token: tokens[0]),
+                    squareLeftToken: tokens[1],
+                    argument: InfixOperatorExpressionNode(
+                        left: IntegerLiteralNode(token: tokens[2]),
+                        operator: BinaryOperatorNode(token: tokens[3]),
+                        right: IdentifierNode(token: tokens[4])
+                    ),
+                    squareRightToken: tokens[5]
                 ),
-                squareRightToken: tokens[5]
+                semicolonToken: tokens[6]
             )
         )
     }

--- a/Tests/ParserTest/FunctionTest.swift
+++ b/Tests/ParserTest/FunctionTest.swift
@@ -33,8 +33,7 @@ final class FunctionTest: XCTestCase {
                             statements: [
                                 IntegerLiteralNode(token: tokens[5]),
                                 IntegerLiteralNode(token: tokens[7])
-                            ],
-                            sourceTokens: Array(tokens[4...9])
+                            ]
                         )
                     )
                 ],
@@ -73,8 +72,7 @@ final class FunctionTest: XCTestCase {
                             statements: [
                                 IntegerLiteralNode(token: tokens[6]),
                                 IntegerLiteralNode(token: tokens[8])
-                            ],
-                            sourceTokens: Array(tokens[5...10])
+                            ]
                         )
                     )
                 ],
@@ -94,7 +92,12 @@ final class FunctionTest: XCTestCase {
 
         XCTAssertEqual(
             node as! FunctionCallExpressionNode,
-            FunctionCallExpressionNode(token: tokens[0], arguments: [], sourceTokens: Array(tokens[0...2]))
+            FunctionCallExpressionNode(
+                identifierToken: tokens[0],
+                parenthesisLeftToken: tokens[1],
+                arguments: [],
+                parenthesisRightToken: tokens[2]
+            )
         )
     }
 
@@ -132,8 +135,7 @@ final class FunctionTest: XCTestCase {
                         block: BlockStatementNode(
                             statements: [
                                 IntegerLiteralNode(token: tokens[10])
-                            ],
-                            sourceTokens: Array(tokens[9...12])
+                            ]
                         )
                     )
                 ],
@@ -157,12 +159,13 @@ final class FunctionTest: XCTestCase {
         XCTAssertEqual(
             node as! FunctionCallExpressionNode,
             FunctionCallExpressionNode(
-                token: tokens[0], 
+                identifierToken: tokens[0],
+                parenthesisLeftToken: tokens[1],
                 arguments: [
                     IntegerLiteralNode(token: tokens[2]),
                     IdentifierNode(token: tokens[4])
                 ],
-                sourceTokens: Array(tokens[0...5])
+                parenthesisRightToken: tokens[5]
             )
         )
     }
@@ -201,8 +204,7 @@ final class FunctionTest: XCTestCase {
                         block: BlockStatementNode(
                             statements: [
                                 IntegerLiteralNode(token: tokens[5])
-                            ],
-                            sourceTokens: Array(tokens[4...7])
+                            ]
                         )
                     ),
                     FunctionDeclNode(
@@ -214,8 +216,7 @@ final class FunctionTest: XCTestCase {
                         block: BlockStatementNode(
                             statements: [
                                 IntegerLiteralNode(token: tokens[13])
-                            ],
-                            sourceTokens: Array(tokens[12...15])
+                            ]
                         )
                     )
                 ],
@@ -263,10 +264,9 @@ final class FunctionTest: XCTestCase {
                 identifierNode: IdentifierNode(token: tokens[0]),
                 squareLeftToken: tokens[1],
                 argument: InfixOperatorExpressionNode(
-                    operator: BinaryOperatorNode(token: tokens[3]),
                     left: IntegerLiteralNode(token: tokens[2]),
-                    right: IdentifierNode(token: tokens[4]),
-                    sourceTokens: Array(tokens[2...4])
+                    operator: BinaryOperatorNode(token: tokens[3]),
+                    right: IdentifierNode(token: tokens[4])
                 ),
                 squareRightToken: tokens[5]
             )

--- a/Tests/ParserTest/OperatorPriorityTest.swift
+++ b/Tests/ParserTest/OperatorPriorityTest.swift
@@ -15,16 +15,21 @@ final class OperatorPriorityTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[0]), 
-                    operator: BinaryOperatorNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[2])
-                ), 
-                operator: BinaryOperatorNode(token: tokens[3]),
-                right: IntegerLiteralNode(token: tokens[4])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: InfixOperatorExpressionNode(
+                        left: IntegerLiteralNode(token: tokens[0]),
+                        operator: BinaryOperatorNode(token: tokens[1]),
+                        right: IntegerLiteralNode(token: tokens[2])
+                    ),
+                    operator: BinaryOperatorNode(token: tokens[3]),
+                    right: IntegerLiteralNode(token: tokens[4])
+                ),
+                semicolonToken: tokens[5]
             )
         )
     }
@@ -40,16 +45,21 @@ final class OperatorPriorityTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[0]),
-                    operator: BinaryOperatorNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[2])
-                ), 
-                operator: BinaryOperatorNode(token: tokens[3]),
-                right: IntegerLiteralNode(token: tokens[4])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: InfixOperatorExpressionNode(
+                        left: IntegerLiteralNode(token: tokens[0]),
+                        operator: BinaryOperatorNode(token: tokens[1]),
+                        right: IntegerLiteralNode(token: tokens[2])
+                    ),
+                    operator: BinaryOperatorNode(token: tokens[3]),
+                    right: IntegerLiteralNode(token: tokens[4])
+                ),
+                semicolonToken: tokens[5]
             )
         )
     }
@@ -65,16 +75,21 @@ final class OperatorPriorityTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IntegerLiteralNode(token: tokens[0]), 
-                operator: BinaryOperatorNode(token: tokens[1]),
-                right: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[2]), 
-                    operator: BinaryOperatorNode(token: tokens[3]),
-                    right: IntegerLiteralNode(token: tokens[4])
-                )
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    operator: BinaryOperatorNode(token: tokens[1]),
+                    right: InfixOperatorExpressionNode(
+                        left: IntegerLiteralNode(token: tokens[2]),
+                        operator: BinaryOperatorNode(token: tokens[3]),
+                        right: IntegerLiteralNode(token: tokens[4])
+                    )
+                ),
+                semicolonToken: tokens[5]
             )
         )
     }
@@ -92,16 +107,25 @@ final class OperatorPriorityTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[1]), 
-                    operator: BinaryOperatorNode(token: tokens[2]),
-                    right: IntegerLiteralNode(token: tokens[3])
-                ), 
-                operator: BinaryOperatorNode(token: tokens[5]),
-                right: IntegerLiteralNode(token: tokens[6])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: TupleExpressionNode(
+                        parenthesisLeftToken: tokens[0],
+                        expression: InfixOperatorExpressionNode(
+                            left: IntegerLiteralNode(token: tokens[1]),
+                            operator: BinaryOperatorNode(token: tokens[2]),
+                            right: IntegerLiteralNode(token: tokens[3])
+                        ),
+                        parenthesisRightToken: tokens[4]
+                    ),
+                    operator: BinaryOperatorNode(token: tokens[5]),
+                    right: IntegerLiteralNode(token: tokens[6])
+                ),
+                semicolonToken: tokens[7]
             )
         )
     }

--- a/Tests/ParserTest/OperatorPriorityTest.swift
+++ b/Tests/ParserTest/OperatorPriorityTest.swift
@@ -18,15 +18,13 @@ final class OperatorPriorityTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
-                operator: BinaryOperatorNode(token: tokens[3]),
                 left: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[0]), 
                     operator: BinaryOperatorNode(token: tokens[1]),
-                    left: IntegerLiteralNode(token: tokens[0]),
-                    right: IntegerLiteralNode(token: tokens[2]),
-                    sourceTokens: Array(tokens[0...2])
-                ),
-                right: IntegerLiteralNode(token: tokens[4]),
-                sourceTokens: Array(tokens[0...4])
+                    right: IntegerLiteralNode(token: tokens[2])
+                ), 
+                operator: BinaryOperatorNode(token: tokens[3]),
+                right: IntegerLiteralNode(token: tokens[4])
             )
         )
     }
@@ -45,15 +43,13 @@ final class OperatorPriorityTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
-                operator: BinaryOperatorNode(token: tokens[3]),
                 left: InfixOperatorExpressionNode(
-                    operator: BinaryOperatorNode(token: tokens[1]),
                     left: IntegerLiteralNode(token: tokens[0]),
-                    right: IntegerLiteralNode(token: tokens[2]),
-                    sourceTokens: Array(tokens[0...2])
-                ),
-                right: IntegerLiteralNode(token: tokens[4]),
-                sourceTokens: Array(tokens[0...4])
+                    operator: BinaryOperatorNode(token: tokens[1]),
+                    right: IntegerLiteralNode(token: tokens[2])
+                ), 
+                operator: BinaryOperatorNode(token: tokens[3]),
+                right: IntegerLiteralNode(token: tokens[4])
             )
         )
     }
@@ -72,15 +68,13 @@ final class OperatorPriorityTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
+                left: IntegerLiteralNode(token: tokens[0]), 
                 operator: BinaryOperatorNode(token: tokens[1]),
-                left: IntegerLiteralNode(token: tokens[0]),
                 right: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[2]), 
                     operator: BinaryOperatorNode(token: tokens[3]),
-                    left: IntegerLiteralNode(token: tokens[2]),
-                    right: IntegerLiteralNode(token: tokens[4]),
-                    sourceTokens: Array(tokens[2...4])
-                ),
-                sourceTokens: Array(tokens[0...4])
+                    right: IntegerLiteralNode(token: tokens[4])
+                )
             )
         )
     }
@@ -101,15 +95,13 @@ final class OperatorPriorityTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
-                operator: BinaryOperatorNode(token: tokens[5]),
                 left: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[1]), 
                     operator: BinaryOperatorNode(token: tokens[2]),
-                    left: IntegerLiteralNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[3]), 
-                    sourceTokens: Array(tokens[1...3])
-                ),
-                right: IntegerLiteralNode(token: tokens[6]),
-                sourceTokens: Array(tokens[0...6])
+                    right: IntegerLiteralNode(token: tokens[3])
+                ), 
+                operator: BinaryOperatorNode(token: tokens[5]),
+                right: IntegerLiteralNode(token: tokens[6])
             )
         )
     }

--- a/Tests/ParserTest/OperatorsTest.swift
+++ b/Tests/ParserTest/OperatorsTest.swift
@@ -16,10 +16,9 @@ final class OperatorsTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
+                left: IntegerLiteralNode(token: tokens[0]), 
                 operator: BinaryOperatorNode(token: tokens[1]),
-                left: IntegerLiteralNode(token: tokens[0]),
-                right: IntegerLiteralNode(token: tokens[2]),
-                sourceTokens: Array(tokens[0...2])
+                right: IntegerLiteralNode(token: tokens[2])
             )
         )
     }
@@ -36,10 +35,9 @@ final class OperatorsTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
-                operator: BinaryOperatorNode(token: tokens[1]),
                 left: IntegerLiteralNode(token: tokens[0]),
-                right: IntegerLiteralNode(token: tokens[2]),
-                sourceTokens: Array(tokens[0...2])
+                operator: BinaryOperatorNode(token: tokens[1]),
+                right: IntegerLiteralNode(token: tokens[2])
             )
         )
     }
@@ -56,10 +54,9 @@ final class OperatorsTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
+                left: IntegerLiteralNode(token: tokens[0]), 
                 operator: BinaryOperatorNode(token: tokens[1]),
-                left: IntegerLiteralNode(token: tokens[0]),
-                right: IntegerLiteralNode(token: tokens[2]),
-                sourceTokens: Array(tokens[0...2])
+                right: IntegerLiteralNode(token: tokens[2])
             )
         )
     }
@@ -76,10 +73,9 @@ final class OperatorsTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
+                left: IntegerLiteralNode(token: tokens[0]), 
                 operator: BinaryOperatorNode(token: tokens[1]),
-                left: IntegerLiteralNode(token: tokens[0]),
-                right: IntegerLiteralNode(token: tokens[2]),
-                sourceTokens: Array(tokens[0...2])
+                right: IntegerLiteralNode(token: tokens[2])
             )
         )
     }
@@ -109,10 +105,9 @@ final class OperatorsTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
+                left: IntegerLiteralNode(token: .number("0", sourceIndex: 1)), 
                 operator: BinaryOperatorNode(token: tokens[0]),
-                left: IntegerLiteralNode(token: .number("0", sourceIndex: 1)),
-                right: IntegerLiteralNode(token: tokens[1]),
-                sourceTokens: Array(tokens[0...1])
+                right: IntegerLiteralNode(token: tokens[1])
             )
         )
     }
@@ -129,8 +124,7 @@ final class OperatorsTest: XCTestCase {
             node as! PrefixOperatorExpressionNode,
             PrefixOperatorExpressionNode(
                 operator: tokens[0],
-                right: IdentifierNode(token: tokens[1]),
-                sourceTokens: Array(tokens[0...1])
+                expression: IdentifierNode(token: tokens[1])
             )
         )
     }
@@ -147,8 +141,7 @@ final class OperatorsTest: XCTestCase {
             node as! PrefixOperatorExpressionNode,
             PrefixOperatorExpressionNode(
                 operator: tokens[0],
-                right: IdentifierNode(token: tokens[1]),
-                sourceTokens: Array(tokens[0...1])
+                expression: IdentifierNode(token: tokens[1])
             )
         )
     }
@@ -165,10 +158,9 @@ final class OperatorsTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
+                left: IntegerLiteralNode(token: tokens[0]), 
                 operator: BinaryOperatorNode(token: tokens[1]),
-                left: IntegerLiteralNode(token: tokens[0]),
-                right: IntegerLiteralNode(token: tokens[2]),
-                sourceTokens: Array(tokens[0...2])
+                right: IntegerLiteralNode(token: tokens[2])
             )
         )
     }
@@ -185,10 +177,9 @@ final class OperatorsTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
+                left: IntegerLiteralNode(token: tokens[0]), 
                 operator: BinaryOperatorNode(token: tokens[1]),
-                left: IntegerLiteralNode(token: tokens[0]),
-                right: IntegerLiteralNode(token: tokens[2]),
-                sourceTokens: Array(tokens[0...2])
+                right: IntegerLiteralNode(token: tokens[2])
             )
         )
     }
@@ -205,10 +196,9 @@ final class OperatorsTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
+                left: IntegerLiteralNode(token: tokens[0]), 
                 operator: BinaryOperatorNode(token: tokens[1]),
-                left: IntegerLiteralNode(token: tokens[0]),
-                right: IntegerLiteralNode(token: tokens[2]),
-                sourceTokens: Array(tokens[0...2])
+                right: IntegerLiteralNode(token: tokens[2])
             )
         )
     }
@@ -225,10 +215,9 @@ final class OperatorsTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
+                left: IntegerLiteralNode(token: tokens[0]), 
                 operator: BinaryOperatorNode(token: tokens[1]),
-                left: IntegerLiteralNode(token: tokens[0]),
-                right: IntegerLiteralNode(token: tokens[2]),
-                sourceTokens: Array(tokens[0...2])
+                right: IntegerLiteralNode(token: tokens[2])
             )
         )
     }
@@ -245,10 +234,9 @@ final class OperatorsTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
-                operator: BinaryOperatorNode(token: tokens[1]),
                 left: IntegerLiteralNode(token: tokens[0]),
-                right: IntegerLiteralNode(token: tokens[2]),
-                sourceTokens: Array(tokens[0...2])
+                operator: BinaryOperatorNode(token: tokens[1]),
+                right: IntegerLiteralNode(token: tokens[2])
             )
         )
     }
@@ -265,10 +253,9 @@ final class OperatorsTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
-                operator: BinaryOperatorNode(token: tokens[1]),
                 left: IntegerLiteralNode(token: tokens[0]),
-                right: IntegerLiteralNode(token: tokens[2]),
-                sourceTokens: Array(tokens[0...2])
+                operator: BinaryOperatorNode(token: tokens[1]),
+                right: IntegerLiteralNode(token: tokens[2])
             )
         )
     }

--- a/Tests/ParserTest/OperatorsTest.swift
+++ b/Tests/ParserTest/OperatorsTest.swift
@@ -13,12 +13,17 @@ final class OperatorsTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IntegerLiteralNode(token: tokens[0]), 
-                operator: BinaryOperatorNode(token: tokens[1]),
-                right: IntegerLiteralNode(token: tokens[2])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    operator: BinaryOperatorNode(token: tokens[1]),
+                    right: IntegerLiteralNode(token: tokens[2])
+                ),
+                semicolonToken: tokens[3]
             )
         )
     }
@@ -32,12 +37,17 @@ final class OperatorsTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IntegerLiteralNode(token: tokens[0]),
-                operator: BinaryOperatorNode(token: tokens[1]),
-                right: IntegerLiteralNode(token: tokens[2])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    operator: BinaryOperatorNode(token: tokens[1]),
+                    right: IntegerLiteralNode(token: tokens[2])
+                ),
+                semicolonToken: tokens[3]
             )
         )
     }
@@ -51,12 +61,17 @@ final class OperatorsTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IntegerLiteralNode(token: tokens[0]), 
-                operator: BinaryOperatorNode(token: tokens[1]),
-                right: IntegerLiteralNode(token: tokens[2])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    operator: BinaryOperatorNode(token: tokens[1]),
+                    right: IntegerLiteralNode(token: tokens[2])
+                ),
+                semicolonToken: tokens[3]
             )
         )
     }
@@ -70,12 +85,17 @@ final class OperatorsTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IntegerLiteralNode(token: tokens[0]), 
-                operator: BinaryOperatorNode(token: tokens[1]),
-                right: IntegerLiteralNode(token: tokens[2])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    operator: BinaryOperatorNode(token: tokens[1]),
+                    right: IntegerLiteralNode(token: tokens[2])
+                ),
+                semicolonToken: tokens[3]
             )
         )
     }
@@ -88,9 +108,17 @@ final class OperatorsTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! IntegerLiteralNode,
-            IntegerLiteralNode(token: tokens[1])
+            node,
+            BlockItemNode(
+                item: PrefixOperatorExpressionNode(
+                    operator: tokens[0],
+                    expression: IntegerLiteralNode(token: tokens[1])
+                ),
+                semicolonToken: tokens[2]
+            )
         )
     }
 
@@ -102,12 +130,16 @@ final class OperatorsTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IntegerLiteralNode(token: .number("0", sourceIndex: 1)), 
-                operator: BinaryOperatorNode(token: tokens[0]),
-                right: IntegerLiteralNode(token: tokens[1])
+            node,
+            BlockItemNode(
+                item: PrefixOperatorExpressionNode(
+                    operator: tokens[0],
+                    expression: IntegerLiteralNode(token: tokens[1])
+                ),
+                semicolonToken: tokens[2]
             )
         )
     }
@@ -120,11 +152,16 @@ final class OperatorsTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! PrefixOperatorExpressionNode,
-            PrefixOperatorExpressionNode(
-                operator: tokens[0],
-                expression: IdentifierNode(token: tokens[1])
+            node,
+            BlockItemNode(
+                item: PrefixOperatorExpressionNode(
+                    operator: tokens[0],
+                    expression: IdentifierNode(token: tokens[1])
+                ),
+                semicolonToken: tokens[2]
             )
         )
     }
@@ -137,11 +174,16 @@ final class OperatorsTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! PrefixOperatorExpressionNode,
-            PrefixOperatorExpressionNode(
-                operator: tokens[0],
-                expression: IdentifierNode(token: tokens[1])
+            node,
+            BlockItemNode(
+                item: PrefixOperatorExpressionNode(
+                    operator: tokens[0],
+                    expression: IdentifierNode(token: tokens[1])
+                ),
+                semicolonToken: tokens[2]
             )
         )
     }
@@ -155,12 +197,17 @@ final class OperatorsTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IntegerLiteralNode(token: tokens[0]), 
-                operator: BinaryOperatorNode(token: tokens[1]),
-                right: IntegerLiteralNode(token: tokens[2])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    operator: BinaryOperatorNode(token: tokens[1]),
+                    right: IntegerLiteralNode(token: tokens[2])
+                ),
+                semicolonToken: tokens[3]
             )
         )
     }
@@ -174,12 +221,17 @@ final class OperatorsTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IntegerLiteralNode(token: tokens[0]), 
-                operator: BinaryOperatorNode(token: tokens[1]),
-                right: IntegerLiteralNode(token: tokens[2])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    operator: BinaryOperatorNode(token: tokens[1]),
+                    right: IntegerLiteralNode(token: tokens[2])
+                ),
+                semicolonToken: tokens[3]
             )
         )
     }
@@ -193,12 +245,17 @@ final class OperatorsTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IntegerLiteralNode(token: tokens[0]), 
-                operator: BinaryOperatorNode(token: tokens[1]),
-                right: IntegerLiteralNode(token: tokens[2])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    operator: BinaryOperatorNode(token: tokens[1]),
+                    right: IntegerLiteralNode(token: tokens[2])
+                ),
+                semicolonToken: tokens[3]
             )
         )
     }
@@ -212,12 +269,17 @@ final class OperatorsTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IntegerLiteralNode(token: tokens[0]), 
-                operator: BinaryOperatorNode(token: tokens[1]),
-                right: IntegerLiteralNode(token: tokens[2])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    operator: BinaryOperatorNode(token: tokens[1]),
+                    right: IntegerLiteralNode(token: tokens[2])
+                ),
+                semicolonToken: tokens[3]
             )
         )
     }
@@ -231,12 +293,17 @@ final class OperatorsTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IntegerLiteralNode(token: tokens[0]),
-                operator: BinaryOperatorNode(token: tokens[1]),
-                right: IntegerLiteralNode(token: tokens[2])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    operator: BinaryOperatorNode(token: tokens[1]),
+                    right: IntegerLiteralNode(token: tokens[2])
+                ),
+                semicolonToken: tokens[3]
             )
         )
     }
@@ -250,16 +317,22 @@ final class OperatorsTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IntegerLiteralNode(token: tokens[0]),
-                operator: BinaryOperatorNode(token: tokens[1]),
-                right: IntegerLiteralNode(token: tokens[2])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IntegerLiteralNode(token: tokens[0]),
+                    operator: BinaryOperatorNode(token: tokens[1]),
+                    right: IntegerLiteralNode(token: tokens[2])
+                ),
+                semicolonToken: tokens[3]
             )
         )
     }
 
+    // FIXME: sizeofって本当にAST上で置き換えるの？
     func testSizeof() throws {
         let tokens: [Token] = [
             .keyword(.sizeof, sourceIndex: 0),
@@ -271,8 +344,11 @@ final class OperatorsTest: XCTestCase {
         let node = try Parser(tokens: tokens).stmt()
 
         XCTAssertEqual(
-            node as! IntegerLiteralNode,
-            IntegerLiteralNode(token: .number("8", sourceIndex: 7))
+            node,
+            BlockItemNode(
+                item: IntegerLiteralNode(token: .number("8", sourceIndex: 6)),
+                semicolonToken: tokens[4]
+            )
         )
     }
 }

--- a/Tests/ParserTest/ReturnTest.swift
+++ b/Tests/ParserTest/ReturnTest.swift
@@ -12,11 +12,16 @@ final class ReturnTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! ReturnStatementNode,
-            ReturnStatementNode(
-                returnToken: tokens[0],
-                expression: IntegerLiteralNode(token: tokens[1])
+            node,
+            BlockItemNode(
+                item: ReturnStatementNode(
+                    returnToken: tokens[0],
+                    expression: IntegerLiteralNode(token: tokens[1])
+                ),
+                semicolonToken: tokens[2]
             )
         )
     }

--- a/Tests/ParserTest/ReturnTest.swift
+++ b/Tests/ParserTest/ReturnTest.swift
@@ -15,9 +15,8 @@ final class ReturnTest: XCTestCase {
         XCTAssertEqual(
             node as! ReturnStatementNode,
             ReturnStatementNode(
-                token: tokens[0],
-                expression: IntegerLiteralNode(token: tokens[1]),
-                sourceTokens: Array(tokens[0...1])
+                returnToken: tokens[0],
+                expression: IntegerLiteralNode(token: tokens[1])
             )
         )
     }

--- a/Tests/ParserTest/StringLiteralTest.swift
+++ b/Tests/ParserTest/StringLiteralTest.swift
@@ -29,10 +29,9 @@ final class StringLiteralTest: XCTestCase {
         XCTAssertEqual(
             node as! InfixOperatorExpressionNode,
             InfixOperatorExpressionNode(
+                left: IdentifierNode(token: tokens[0]), 
                 operator: AssignNode(token: tokens[1]),
-                left: IdentifierNode(token: tokens[0]),
-                right: StringLiteralNode(token: tokens[2]),
-                sourceTokens: Array(tokens[0...2])
+                right: StringLiteralNode(token: tokens[2])
             )
         )
     }

--- a/Tests/ParserTest/StringLiteralTest.swift
+++ b/Tests/ParserTest/StringLiteralTest.swift
@@ -11,9 +11,14 @@ final class StringLiteralTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! StringLiteralNode,
-            StringLiteralNode(token: tokens[0])
+            node,
+            BlockItemNode(
+                item: StringLiteralNode(token: tokens[0]),
+                semicolonToken: tokens[1]
+            )
         )
     }
 
@@ -26,12 +31,17 @@ final class StringLiteralTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! InfixOperatorExpressionNode,
-            InfixOperatorExpressionNode(
-                left: IdentifierNode(token: tokens[0]), 
-                operator: AssignNode(token: tokens[1]),
-                right: StringLiteralNode(token: tokens[2])
+            node,
+            BlockItemNode(
+                item: InfixOperatorExpressionNode(
+                    left: IdentifierNode(token: tokens[0]),
+                    operator: AssignNode(token: tokens[1]),
+                    right: StringLiteralNode(token: tokens[2])
+                ),
+                semicolonToken: tokens[3]
             )
         )
     }

--- a/Tests/ParserTest/VariableTest.swift
+++ b/Tests/ParserTest/VariableTest.swift
@@ -12,9 +12,17 @@ final class VariableTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! VariableDeclNode,
-            VariableDeclNode(type: TypeNode(typeToken: tokens[0]), identifierToken: tokens[1])
+            node,
+            BlockItemNode(
+                item: VariableDeclNode(
+                    type: TypeNode(typeToken: tokens[0]),
+                    identifierToken: tokens[1]
+                ),
+                semicolonToken: tokens[2]
+            )
         )
     }
 
@@ -28,13 +36,18 @@ final class VariableTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! VariableDeclNode,
-            VariableDeclNode(
-                type: TypeNode(typeToken: tokens[0]),
-                identifierToken: tokens[1],
-                initializerToken: tokens[2],
-                initializerExpr: IntegerLiteralNode(token: tokens[3])
+            node,
+            BlockItemNode(
+                item: VariableDeclNode(
+                    type: TypeNode(typeToken: tokens[0]),
+                    identifierToken: tokens[1],
+                    initializerToken: tokens[2],
+                    initializerExpr: IntegerLiteralNode(token: tokens[3])
+                ),
+                semicolonToken: tokens[4]
             )
         )
     }
@@ -48,9 +61,20 @@ final class VariableTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! VariableDeclNode,
-            VariableDeclNode(type: PointerTypeNode(referenceType: TypeNode(typeToken: tokens[0]), pointerToken: tokens[1]), identifierToken: tokens[2])
+            node,
+            BlockItemNode(
+                item: VariableDeclNode(
+                    type: PointerTypeNode(
+                        referenceType: TypeNode(typeToken: tokens[0]),
+                        pointerToken: tokens[1]
+                    ),
+                    identifierToken: tokens[2]
+                ),
+                semicolonToken: tokens[3]
+            )
         )
     }
 
@@ -64,12 +88,27 @@ final class VariableTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
-            node as! VariableDeclNode,
-            VariableDeclNode(type: PointerTypeNode(referenceType: PointerTypeNode(referenceType: TypeNode(typeToken: tokens[0]), pointerToken: tokens[1]), pointerToken: tokens[2]) , identifierToken: tokens[3])
+            node,
+            BlockItemNode(
+                item: VariableDeclNode(
+                    type: PointerTypeNode(
+                        referenceType: PointerTypeNode(
+                            referenceType: TypeNode(typeToken: tokens[0]),
+                            pointerToken: tokens[1]
+                        ),
+                        pointerToken: tokens[2]
+                    ),
+                    identifierToken: tokens[3]
+                ),
+                semicolonToken: tokens[4]
+            )
         )
     }
 
+    // FIXME: ArrayTypeのsourceTokenの順序がおかしくなる
     func testDeclVariableArray() throws {
         let tokens: [Token] = [
             .type(.int, sourceIndex: 0),
@@ -82,19 +121,23 @@ final class VariableTest: XCTestCase {
         let node = try Parser(tokens: tokens).stmt()
 
         XCTAssertEqual(
-            node as! VariableDeclNode,
-            VariableDeclNode(
-                type: ArrayTypeNode(
-                    elementType: TypeNode(typeToken: tokens[0]),
-                    squareLeftToken: tokens[2],
-                    arraySizeToken: tokens[3],
-                    squareRightToken: tokens[4]
+            node,
+            BlockItemNode(
+                item: VariableDeclNode(
+                    type: ArrayTypeNode(
+                        elementType: TypeNode(typeToken: tokens[0]),
+                        squareLeftToken: tokens[2],
+                        arraySizeToken: tokens[3],
+                        squareRightToken: tokens[4]
+                    ),
+                    identifierToken: tokens[1]
                 ),
-                identifierToken: tokens[1]
+                semicolonToken: tokens[5]
             )
         )
     }
 
+    // FIXME: ArrayTypeのsourceTokenの順序がおかしくなる
     func testDeclAndInitVariableArray() throws {
         let tokens: [Token] = [
             .type(.int, sourceIndex: 0),
@@ -113,28 +156,32 @@ final class VariableTest: XCTestCase {
         let node = try Parser(tokens: tokens).stmt()
 
         XCTAssertEqual(
-            node as! VariableDeclNode,
-            VariableDeclNode(
-                type: ArrayTypeNode(
-                    elementType: TypeNode(typeToken: tokens[0]),
-                    squareLeftToken: tokens[2],
-                    arraySizeToken: tokens[3],
-                    squareRightToken: tokens[4]
+            node,
+            BlockItemNode(
+                item: VariableDeclNode(
+                    type: ArrayTypeNode(
+                        elementType: TypeNode(typeToken: tokens[0]),
+                        squareLeftToken: tokens[2],
+                        arraySizeToken: tokens[3],
+                        squareRightToken: tokens[4]
+                    ),
+                    identifierToken: tokens[1],
+                    initializerToken: tokens[5],
+                    initializerExpr: ArrayExpressionNode(
+                        braceLeft: tokens[6],
+                        exprListNodes: [
+                            ExpressionListItemNode(expression: IntegerLiteralNode(token: tokens[7]), comma: tokens[8]),
+                            ExpressionListItemNode(expression: IntegerLiteralNode(token: tokens[9]))
+                        ],
+                        braceRight: tokens[10]
+                    )
                 ),
-                identifierToken: tokens[1],
-                initializerToken: tokens[5],
-                initializerExpr: ArrayExpressionNode(
-                    braceLeft: tokens[6],
-                    exprListNodes: [
-                        IntegerLiteralNode(token: tokens[7]),
-                        IntegerLiteralNode(token: tokens[9])
-                    ],
-                    braceRight: tokens[10]
-                )
+                semicolonToken: tokens[11]
             )
         )
     }
 
+    // FIXME: ArrayTypeのsourceTokenの順序がおかしくなる
     func testDeclAndInitVariableStringLiteral() throws {
         let tokens: [Token] = [
             .type(.char, sourceIndex: 0),
@@ -149,21 +196,25 @@ final class VariableTest: XCTestCase {
         let node = try Parser(tokens: tokens).stmt()
 
         XCTAssertEqual(
-            node as! VariableDeclNode,
-            VariableDeclNode(
-                type: ArrayTypeNode(
-                    elementType: TypeNode(typeToken: tokens[0]),
-                    squareLeftToken: tokens[2],
-                    arraySizeToken: tokens[3],
-                    squareRightToken: tokens[4]
+            node,
+            BlockItemNode(
+                item: VariableDeclNode(
+                    type: ArrayTypeNode(
+                        elementType: TypeNode(typeToken: tokens[0]),
+                        squareLeftToken: tokens[2],
+                        arraySizeToken: tokens[3],
+                        squareRightToken: tokens[4]
+                    ),
+                    identifierToken: tokens[1],
+                    initializerToken: tokens[5],
+                    initializerExpr: StringLiteralNode(token: tokens[6])
                 ),
-                identifierToken: tokens[1],
-                initializerToken: tokens[5],
-                initializerExpr: StringLiteralNode(token: tokens[6])
+                semicolonToken: tokens[7]
             )
         )
     }
 
+    // FIXME: ArrayTypeのsourceTokenの順序がおかしくなる
     func testDeclVariableArrayPointer() throws {
         let tokens: [Token] = [
             .type(.int, sourceIndex: 0),
@@ -177,15 +228,18 @@ final class VariableTest: XCTestCase {
         let node = try Parser(tokens: tokens).stmt()
 
         XCTAssertEqual(
-            node as! VariableDeclNode,
-            VariableDeclNode(
-                type: ArrayTypeNode(
-                    elementType: PointerTypeNode(referenceType: TypeNode(typeToken: tokens[0]), pointerToken: tokens[1]),
-                    squareLeftToken: tokens[3],
-                    arraySizeToken: tokens[4],
-                    squareRightToken: tokens[5]
+            node,
+            BlockItemNode(
+                item: VariableDeclNode(
+                    type: ArrayTypeNode(
+                        elementType: PointerTypeNode(referenceType: TypeNode(typeToken: tokens[0]), pointerToken: tokens[1]),
+                        squareLeftToken: tokens[3],
+                        arraySizeToken: tokens[4],
+                        squareRightToken: tokens[5]
+                    ),
+                    identifierToken: tokens[2]
                 ),
-                identifierToken: tokens[2]
+                semicolonToken: tokens[6]
             )
         )
     }
@@ -198,12 +252,19 @@ final class VariableTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).parse()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
             node,
             SourceFileNode(
-                functions: [],
-                globalVariables: [
-                    VariableDeclNode(type: TypeNode(typeToken: tokens[0]), identifierToken: tokens[1])
+                statements: [
+                    BlockItemNode(
+                        item: VariableDeclNode(
+                            type: TypeNode(typeToken: tokens[0]),
+                            identifierToken: tokens[1]
+                        ),
+                        semicolonToken: tokens[2]
+                    )
                 ]
             )
         )
@@ -218,12 +279,22 @@ final class VariableTest: XCTestCase {
         ]
         let node = try Parser(tokens: tokens).parse()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
             node,
             SourceFileNode(
-                functions: [],
-                globalVariables: [
-                    VariableDeclNode(type: PointerTypeNode(referenceType: TypeNode(typeToken: tokens[0]), pointerToken: tokens[1]), identifierToken: tokens[2])
+                statements: [
+                    BlockItemNode(
+                        item: VariableDeclNode(
+                            type: PointerTypeNode(
+                                referenceType: TypeNode(typeToken: tokens[0]),
+                                pointerToken: tokens[1]
+                            ),
+                            identifierToken: tokens[2]
+                        ),
+                        semicolonToken: tokens[3]
+                    )
                 ]
             )
         )


### PR DESCRIPTION
# 概要
- Nodeのinitで`sourceTokens: [Token]`の代わりに、各記号`(`, `,`, `;`を受け取るように変える
    - これによってcomputed propertyで`sourceTokens: [Token]`が復元できる
- 入力tokenとsourceTokensの一致を確かめるテストケースを追加

# 実装
- セミコロンは`BlockItemNode`で管理
    - StatementとStatementの区切りなので、VariableDecl（Statement自体）とかがセミコロンを持つのはおかしいため

# 問題
- 配列の`int a[5]`の記法だけNodeとsourceTokenの位置が前後してしまうので保留中