### PR TITLE
NodeはTokenを直接もたずTokenNodeを持つ

### DIFF
--- a/Sources/Parser/Node/Node.swift
+++ b/Sources/Parser/Node/Node.swift
@@ -1,6 +1,8 @@
 import Tokenizer
 
 public enum NodeKind {
+    case token
+
     case integerLiteral
     case identifier
     case stringLiteral
@@ -38,6 +40,12 @@ public protocol NodeProtocol: Equatable {
     var kind: NodeKind { get }
     var sourceTokens: [Token] { get }
     var children: [any NodeProtocol] { get }
+}
+
+public extension NodeProtocol {
+    var sourceTokens: [Token] {
+        children.flatMap { $0.sourceTokens }
+    }
 }
 
 extension NodeProtocol {

--- a/Sources/Parser/Node/PrimaryNode.swift
+++ b/Sources/Parser/Node/PrimaryNode.swift
@@ -1,25 +1,49 @@
 import Tokenizer
 
-public class IntegerLiteralNode: NodeProtocol {
+public class TokenNode: NodeProtocol {
 
     // MARK: - Property
 
-    public let kind: NodeKind = .integerLiteral
-
+    public let kind: NodeKind = .token
     public var sourceTokens: [Token] {
         [token]
     }
     public let children: [any NodeProtocol] = []
+    
     public let token: Token
 
-    public var literal: String {
-        token.value
+    public var tokenKind: TokenKind {
+        token.kind
+    }
+    public var text: String {
+        token.text
+    }
+    public var description: String {
+        token.description
     }
 
     // MARK: - Initializer
 
     public init(token: Token) {
         self.token = token
+    }
+}
+
+public class IntegerLiteralNode: NodeProtocol {
+
+    // MARK: - Property
+
+    public let kind: NodeKind = .integerLiteral
+    public var children: [any NodeProtocol] {
+        [literal]
+    }
+
+    public let literal: TokenNode
+
+    // MARK: - Initializer
+
+    public init(literal: TokenNode) {
+        self.literal = literal
     }
 }
 
@@ -28,21 +52,16 @@ public class StringLiteralNode: NodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .stringLiteral
-    public var sourceTokens: [Token] {
-        [token]
+    public var children: [any NodeProtocol] {
+        [literal]
     }
-    public let children: [any NodeProtocol] = []
 
-    public let token: Token
-
-    public var value: String {
-        token.value
-    }
+    public let literal: TokenNode
 
     // MARK: - Initializer
 
-    public init(token: Token) {
-        self.token = token
+    public init(literal: TokenNode) {
+        self.literal = literal
     }
 }
 
@@ -51,21 +70,16 @@ public class IdentifierNode: NodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .identifier
-
-    public var sourceTokens: [Token] {
-        [token]
+    public var children: [any NodeProtocol] {
+        [baseName]
     }
-    public let children: [any NodeProtocol] = []
-    public let token: Token
 
-    public var identifierName: String {
-        token.value
-    }
+    public let baseName: TokenNode
 
     // MARK: - Initializer
 
-    public init(token: Token) {
-        self.token = token
+    public init(baseName: TokenNode) {
+        self.baseName = baseName
     }
 }
 
@@ -108,7 +122,7 @@ public class BinaryOperatorNode: NodeProtocol {
     public let kind: NodeKind = .binaryOperator
 
     public var operatorKind: OperatorKind {
-        switch token.kind {
+        switch `operator`.tokenKind {
         case .reserved(.add):
             return .add
 
@@ -143,16 +157,16 @@ public class BinaryOperatorNode: NodeProtocol {
             fatalError()
         }
     }
-    public var sourceTokens: [Token] {
-        [token]
+    public var children: [any NodeProtocol] {
+        [`operator`]
     }
-    public let children: [any NodeProtocol] = []
-    public let token: Token
+
+    public let `operator`: TokenNode
 
     // MARK: - Initializer
 
-    public init(token: Token) {
-        self.token = token
+    public init(operator: TokenNode) {
+        self.operator = `operator`
     }
 }
 
@@ -161,16 +175,15 @@ public class AssignNode: NodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .assign
-
-    public var sourceTokens: [Token] {
-        [token]
+    public var children: [any NodeProtocol] {
+        [equal]
     }
-    public let children: [any NodeProtocol] = []
-    public let token: Token
+
+    public let equal: TokenNode
 
     // MARK: - Initializer
 
-    public init(token: Token) {
-        self.token = token
+    public init(equal: TokenNode) {
+        self.equal = equal
     }
 }

--- a/Sources/Parser/Node/StatementNode.swift
+++ b/Sources/Parser/Node/StatementNode.swift
@@ -5,24 +5,23 @@ public class WhileStatementNode: NodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .whileStatement
-    public var sourceTokens: [Token] {
-        [whileToken, parenthesisLeftToken] + condition.sourceTokens + [parenthesisRightToken] + body.sourceTokens
+    public var children: [any NodeProtocol] {
+        [`while`, parenthesisLeft, condition, parenthesisRight, body]
     }
-    public var children: [any NodeProtocol] { [condition, body] }
 
-    public let whileToken: Token
-    public let parenthesisLeftToken: Token
+    public let `while`: TokenNode
+    public let parenthesisLeft: TokenNode
     public let condition: any NodeProtocol
-    public let parenthesisRightToken: Token
+    public let parenthesisRight: TokenNode
     public let body: BlockItemNode
 
     // MARK: - Initializer
 
-    public init(whileToken: Token, parenthesisLeftToken: Token, condition: any NodeProtocol, parenthesisRightToken: Token, body: BlockItemNode) {
-        self.whileToken = whileToken
-        self.parenthesisLeftToken = parenthesisLeftToken
+    public init(while: TokenNode, parenthesisLeft: TokenNode, condition: any NodeProtocol, parenthesisRight: TokenNode, body: BlockItemNode) {
+        self.while = `while`
+        self.parenthesisLeft = parenthesisLeft
         self.condition = condition
-        self.parenthesisRightToken = parenthesisRightToken
+        self.parenthesisRight = parenthesisRight
         self.body = body
     }
 }
@@ -32,66 +31,41 @@ public class ForStatementNode: NodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .forStatement
-    public var sourceTokens: [Token] {
-        var result = [forToken, parenthesisLeftToken]
-
-        if let pre {
-            result += pre.sourceTokens
-        }
-
-        result += [firstSemicolonToken]
-
-        if let condition {
-            result += condition.sourceTokens
-        }
-
-        result += [secondSemicolonToken]
-
-        if let post {
-            result += post.sourceTokens
-        }
-
-        result += [parenthesisRightToken]
-
-        result += body.sourceTokens
-
-        return result
-    }
     public var children: [any NodeProtocol] {
-        [pre, condition, post, body].compactMap { $0 }
+        [`for`, parenthesisLeft, pre, firstSemicolon, condition, secondSemicolon, post, parenthesisRight, body].compactMap { $0 }
     }
 
-    public let forToken: Token
-    public let parenthesisLeftToken: Token
+    public let `for`: TokenNode
+    public let parenthesisLeft: TokenNode
     public let pre: (any NodeProtocol)?
-    public let firstSemicolonToken: Token
+    public let firstSemicolon: TokenNode
     public let condition: (any NodeProtocol)?
-    public let secondSemicolonToken: Token
+    public let secondSemicolon: TokenNode
     public let post: (any NodeProtocol)?
-    public let parenthesisRightToken: Token
+    public let parenthesisRight: TokenNode
     public let body: BlockItemNode
 
     // MARK: - Initializer
 
     public init(
-        forToken: Token,
-        parenthesisLeftToken: Token,
+        for: TokenNode,
+        parenthesisLeft: TokenNode,
         pre: (any NodeProtocol)?,
-        firstSemicolonToken: Token,
+        firstSemicolon: TokenNode,
         condition: (any NodeProtocol)?,
-        secondSemicolonToken: Token,
+        secondSemicolon: TokenNode,
         post: (any NodeProtocol)?,
-        parenthesisRightToken: Token,
+        parenthesisRight: TokenNode,
         body: BlockItemNode
     ) {
-        self.forToken = forToken
-        self.parenthesisLeftToken = parenthesisLeftToken
+        self.for = `for`
+        self.parenthesisLeft = parenthesisLeft
         self.condition = condition
-        self.firstSemicolonToken = firstSemicolonToken
+        self.firstSemicolon = firstSemicolon
         self.pre = pre
-        self.secondSemicolonToken = secondSemicolonToken
+        self.secondSemicolon = secondSemicolon
         self.post = post
-        self.parenthesisRightToken = parenthesisRightToken
+        self.parenthesisRight = parenthesisRight
         self.body = body
     }
 }
@@ -101,42 +75,33 @@ public class IfStatementNode: NodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .ifStatement
-    public var sourceTokens: [Token] {
-        var result = [ifToken, parenthesisLeftToken] + condition.sourceTokens + [parenthesisRightToken] + trueBody.sourceTokens
-
-        if let elseToken {
-            result.append(elseToken)
-        }
-
-        return result + (falseBody?.sourceTokens ?? [])
-    }
     public var children: [any NodeProtocol] {
-        [condition, trueBody, falseBody as (any NodeProtocol)?].compactMap { $0 }
+        ([`if`, parenthesisLeft, condition, parenthesisRight, trueBody, `else`, falseBody] as [(any NodeProtocol)?]).compactMap { $0 }
     }
 
-    public let ifToken: Token
-    public let parenthesisLeftToken: Token
+    public let `if`: TokenNode
+    public let parenthesisLeft: TokenNode
     public let condition: any NodeProtocol
-    public let parenthesisRightToken: Token
+    public let parenthesisRight: TokenNode
     public let trueBody: BlockItemNode
-    public let elseToken: Token?
+    public let `else`: TokenNode?
     public let falseBody: BlockItemNode?
 
     public init(
-        ifToken: Token,
-        parenthesisLeftToken: Token,
+        if: TokenNode,
+        parenthesisLeft: TokenNode,
         condition: any NodeProtocol,
-        parenthesisRightToken: Token,
+        parenthesisRight: TokenNode,
         trueBody: BlockItemNode,
-        elseToken: Token?,
+        else: TokenNode?,
         falseBody: BlockItemNode?
     ) {
-        self.ifToken = ifToken
-        self.parenthesisLeftToken = parenthesisLeftToken
+        self.if = `if`
+        self.parenthesisLeft = parenthesisLeft
         self.condition = condition
-        self.parenthesisRightToken = parenthesisRightToken
+        self.parenthesisRight = parenthesisRight
         self.trueBody = trueBody
-        self.elseToken = elseToken
+        self.else = `else`
         self.falseBody = falseBody
     }
 }
@@ -146,16 +111,17 @@ public class ReturnStatementNode: NodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .returnStatement
-    public var sourceTokens: [Token] { [returnToken] + expression.sourceTokens }
-    public var children: [any NodeProtocol] { [expression] }
+    public var children: [any NodeProtocol] {
+        [`return`, expression]
+    }
 
-    public let returnToken: Token
+    public let `return`: TokenNode
     public let expression: any NodeProtocol
 
     // MARK: - Initializer
 
-    public init(returnToken: Token, expression: any NodeProtocol) {
-        self.returnToken = returnToken
+    public init(return: TokenNode, expression: any NodeProtocol) {
+        self.return = `return`
         self.expression = expression
     }
 }
@@ -165,21 +131,20 @@ public class BlockStatementNode: NodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .blockStatement
-    public var sourceTokens: [Token] {
-        [braceLeftToken] + items.flatMap { $0.sourceTokens } + [braceRightToken]
+    public var children: [any NodeProtocol] {
+        [braceLeft] + items + [braceRight]
     }
-    public var children: [any NodeProtocol] { items }
 
-    public let braceLeftToken: Token
+    public let braceLeft: TokenNode
     public let items: [BlockItemNode]
-    public let braceRightToken: Token
+    public let braceRight: TokenNode
 
     // MARK: - Initializer
 
-    public init(braceLeftToken: Token, items: [BlockItemNode], braceRightToken: Token) {
-        self.braceLeftToken = braceLeftToken
+    public init(braceLeft: TokenNode, items: [BlockItemNode], braceRight: TokenNode) {
+        self.braceLeft = braceLeft
         self.items = items
-        self.braceRightToken = braceRightToken
+        self.braceRight = braceRight
     }
 }
 
@@ -188,27 +153,18 @@ public class BlockItemNode: NodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .blockItem
-    public var sourceTokens: [Token] {
-        var result = item.sourceTokens
-
-        if let semicolonToken {
-            result += [semicolonToken]
-        }
-
-        return result
-    }
     public var children: [any NodeProtocol] {
-        [item]
+        ([item, semicolon] as [(any NodeProtocol)?]).compactMap { $0 }
     }
 
     public let item: any NodeProtocol
-    public let semicolonToken: Token?
+    public let semicolon: TokenNode?
 
     // MARK: - Initializer
 
-    public init(item: any NodeProtocol, semicolonToken: Token? = nil) {
+    public init(item: any NodeProtocol, semicolon: TokenNode? = nil) {
         self.item = item
-        self.semicolonToken = semicolonToken
+        self.semicolon = semicolon
     }
 }
 
@@ -217,41 +173,32 @@ public class FunctionDeclNode: NodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .functionDecl
-    public var sourceTokens: [Token] {
-        returnTypeNode.sourceTokens 
-        + [functionNameToken, parenthesisLeftToken]
-        + parameterNodes.flatMap { $0.sourceTokens }
-        + [parenthesisRightToken]
-        + block.sourceTokens
+    public var children: [any NodeProtocol] {
+        [returnType, functionName, parenthesisLeft] + parameters + [parenthesisRight, block]
     }
-    public var children: [any NodeProtocol] { [returnTypeNode] + parameterNodes + [block] }
 
-    public let returnTypeNode: any NodeProtocol
-    public let functionNameToken: Token
-    public let parenthesisLeftToken: Token
-    public let parameterNodes: [FunctionParameterNode]
-    public let parenthesisRightToken: Token
+    public let returnType: any NodeProtocol
+    public let functionName: TokenNode
+    public let parenthesisLeft: TokenNode
+    public let parameters: [FunctionParameterNode]
+    public let parenthesisRight: TokenNode
     public let block: BlockStatementNode
-
-    public var functionName: String {
-        functionNameToken.value
-    }
 
     // MARK: - Initializer
 
     public init(
-        returnTypeNode: any NodeProtocol,
-        functionNameToken: Token,
-        parenthesisLeftToken: Token,
-        parameterNodes: [FunctionParameterNode],
-        parenthesisRightToken: Token,
+        returnType: any NodeProtocol,
+        functionName: TokenNode,
+        parenthesisLeft: TokenNode,
+        parameters: [FunctionParameterNode],
+        parenthesisRight: TokenNode,
         block: BlockStatementNode
     ) {
-        self.returnTypeNode = returnTypeNode
-        self.functionNameToken = functionNameToken
-        self.parenthesisLeftToken = parenthesisLeftToken
-        self.parameterNodes = parameterNodes
-        self.parenthesisRightToken = parenthesisRightToken
+        self.returnType = returnType
+        self.functionName = functionName
+        self.parenthesisLeft = parenthesisLeft
+        self.parameters = parameters
+        self.parenthesisRight = parenthesisRight
         self.block = block
     }
 }
@@ -261,38 +208,21 @@ public class VariableDeclNode: NodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .variableDecl
-    public var sourceTokens: [Token] {
-        var tokens = type.sourceTokens + [identifierToken]
-
-        if let initializerToken {
-            tokens += [initializerToken]
-        }
-
-        if let initializerExpr {
-            tokens += initializerExpr.sourceTokens
-        }
-
-        return tokens
-    }
     public var children: [any NodeProtocol] {
-        [type, initializerExpr].compactMap { $0 }
+        [type, identifier, equal, initializerExpr].compactMap { $0 }
     }
 
     public let type: any TypeNodeProtocol
-    public let identifierToken: Token
-    public let initializerToken: Token?
+    public let identifier: TokenNode
+    public let equal: TokenNode?
     public let initializerExpr: (any NodeProtocol)?
-
-    public var identifierName: String {
-        identifierToken.value
-    }
 
     // MARK: - Initializer
 
-    public init(type: any TypeNodeProtocol, identifierToken: Token, initializerToken: Token? = nil, initializerExpr: (any NodeProtocol)? = nil) {
+    public init(type: any TypeNodeProtocol, identifier: TokenNode, equal: TokenNode? = nil, initializerExpr: (any NodeProtocol)? = nil) {
         self.type = type
-        self.identifierToken = identifierToken
-        self.initializerToken = initializerToken
+        self.identifier = identifier
+        self.equal = equal
         self.initializerExpr = initializerExpr
     }
 }
@@ -302,31 +232,20 @@ public class FunctionParameterNode: NodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .functionParameter
-    public var sourceTokens: [Token] {
-        var result = type.sourceTokens + [identifierToken]
-
-        if let commaToken {
-            result += [commaToken]
-        }
-
-        return result
+    public var children: [any NodeProtocol] {
+        ([type, identifier, comma] as [(any NodeProtocol)?]).compactMap { $0 }
     }
-    public var children: [any NodeProtocol] { [type] }
 
     public let type: any TypeNodeProtocol
-    public let identifierToken: Token
-    public let commaToken: Token?
-
-    public var identifierName: String {
-        identifierToken.value
-    }
+    public let identifier: TokenNode
+    public let comma: TokenNode?
 
     // MARK: - Initializer
 
-    public init(type: any TypeNodeProtocol, identifierToken: Token, commaToken: Token? = nil) {
+    public init(type: any TypeNodeProtocol, identifier: TokenNode, comma: TokenNode? = nil) {
         self.type = type
-        self.identifierToken = identifierToken
-        self.commaToken = commaToken
+        self.identifier = identifier
+        self.comma = comma
     }
 }
 
@@ -335,10 +254,6 @@ public class SourceFileNode: NodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .sourceFile
-    public var sourceTokens: [Token] {
-        statements.flatMap { $0.sourceTokens }
-    }
-
     public var children: [any NodeProtocol] {
         statements
     }

--- a/Sources/Parser/Node/TypeNode.swift
+++ b/Sources/Parser/Node/TypeNode.swift
@@ -10,13 +10,14 @@ public class TypeNode: TypeNodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .type
-    public var sourceTokens: [Token] { [typeToken] }
-    public let children: [any NodeProtocol] = []
+    public var children: [any NodeProtocol] {
+        [type]
+    }
 
-    public let typeToken: Token
+    public let type: TokenNode
 
     public var memorySize: Int {
-        return switch typeToken.kind {
+        return switch type.tokenKind {
         case .type(let typeKind):
             switch typeKind {
             case .int: 8
@@ -30,8 +31,8 @@ public class TypeNode: TypeNodeProtocol {
 
     // MARK: - Initializer
 
-    public init(typeToken: Token) {
-        self.typeToken = typeToken
+    public init(type: TokenNode) {
+        self.type = type
     }
 }
 
@@ -40,19 +41,20 @@ public class PointerTypeNode: TypeNodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .pointerType
-    public var sourceTokens: [Token] { referenceType.sourceTokens + [pointerToken] }
-    public var children: [any NodeProtocol] { [referenceType] }
-    public let referenceType: any TypeNodeProtocol
+    public var children: [any NodeProtocol] {
+        [referenceType, pointer]
+    }
 
-    public let pointerToken: Token
+    public let referenceType: any TypeNodeProtocol
+    public let pointer: TokenNode
 
     public let memorySize: Int = 8
 
     // MARK: - Initializer
 
-    public init(referenceType: any TypeNodeProtocol, pointerToken: Token) {
+    public init(referenceType: any TypeNodeProtocol, pointer: TokenNode) {
         self.referenceType = referenceType
-        self.pointerToken = pointerToken
+        self.pointer = pointer
     }
 }
 
@@ -61,28 +63,28 @@ public class ArrayTypeNode: TypeNodeProtocol {
     // MARK: - Property
 
     public let kind: NodeKind = .arrayType
+    public var children: [any NodeProtocol] {
+        [elementType, squareLeft, arraySize, squareRight]
+    }
 
-    public var sourceTokens: [Token] { [squareLeftToken] + elementType.sourceTokens + [squareRightToken] }
-    public var children: [any NodeProtocol] { [elementType] }
     public let elementType: any TypeNodeProtocol
+    public let squareLeft: TokenNode
+    public let arraySize: TokenNode
+    public let squareRight: TokenNode
 
-    public let squareLeftToken: Token
-    public let arraySizeToken: Token
-    public let squareRightToken: Token
-
-    public var arraySize: Int {
-        Int(arraySizeToken.value)!
+    public var arrayLength: Int {
+        Int(arraySize.text)!
     }
 
     public var memorySize: Int {
-        arraySize * elementType.memorySize
+        arrayLength * elementType.memorySize
     }
     // MARK: - Initializer
 
-    public init(elementType: any TypeNodeProtocol, squareLeftToken: Token, arraySizeToken: Token, squareRightToken: Token) {
+    public init(elementType: any TypeNodeProtocol, squareLeft: TokenNode, arraySize: TokenNode, squareRight: TokenNode) {
         self.elementType = elementType
-        self.squareLeftToken = squareLeftToken
-        self.arraySizeToken = arraySizeToken
-        self.squareRightToken = squareRightToken
+        self.squareLeft = squareLeft
+        self.arraySize = arraySize
+        self.squareRight = squareRight
     }
 }

--- a/Sources/Tokenizer/Token.swift
+++ b/Sources/Tokenizer/Token.swift
@@ -8,13 +8,13 @@ public struct Token: Equatable {
     public var sourceRange: SourceRange
 
     /// without trivia
-    public var value: String {
-        kind.value
+    public var text: String {
+        kind.text
     }
 
     /// with trivia
     public var description: String {
-        leadingTrivia + kind.value + trailingTrivia
+        leadingTrivia + kind.text + trailingTrivia
     }
 
     // MARK: - Initializer
@@ -72,7 +72,7 @@ public enum TokenKind: Equatable {
     case identifier(_ value: String)
     case type(_ kind: TypeKind)
 
-    public var value: String {
+    public var text: String {
         switch self {
         case .reserved(let kind):
             return kind.rawValue
@@ -84,7 +84,7 @@ public enum TokenKind: Equatable {
             return value
 
         case .stringLiteral(let value):
-            return value
+            return "\"" + value + "\""
 
         case .identifier(let value):
             return value

--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -74,7 +74,7 @@ public class Tokenizer {
     }
 
     private func extractString() -> TokenKind {
-        var string = ""
+        var content = ""
 
         // 開始の"
         index += 1
@@ -86,12 +86,12 @@ public class Tokenizer {
                 index += 1
                 break
             } else {
-                string += String(nextToken)
+                content += String(nextToken)
                 index += 1
             }
         }
 
-        return .stringLiteral(string)
+        return .stringLiteral(content)
     }
 
     private func extractIdentifier() -> TokenKind {

--- a/Tests/ParserTest/AssignTest.swift
+++ b/Tests/ParserTest/AssignTest.swift
@@ -21,11 +21,11 @@ final class AssignTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IdentifierNode(token: tokens[0]),
-                    operator: AssignNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[2])
+                    left: IdentifierNode(baseName: TokenNode(token: tokens[0])),
+                    operator: AssignNode(equal: TokenNode(token: tokens[1])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[2]))
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }
@@ -49,15 +49,15 @@ final class AssignTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IdentifierNode(token: tokens[0]),
-                    operator: AssignNode(token: tokens[1]),
+                    left: IdentifierNode(baseName: TokenNode(token: tokens[0])),
+                    operator: AssignNode(equal: TokenNode(token: tokens[1])),
                     right: InfixOperatorExpressionNode(
-                        left: IdentifierNode(token: tokens[2]),
-                        operator: AssignNode(token: tokens[3]),
-                        right: IntegerLiteralNode(token: tokens[4])
+                        left: IdentifierNode(baseName: TokenNode(token: tokens[2])),
+                        operator: AssignNode(equal: TokenNode(token: tokens[3])),
+                        right: IntegerLiteralNode(literal: TokenNode(token: tokens[4]))
                     )
                 ),
-                semicolonToken: tokens[5]
+                semicolon: TokenNode(token: tokens[5])
             )
         )
     }
@@ -80,11 +80,11 @@ final class AssignTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[0]),
-                    operator: AssignNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[2])
+                    left: IntegerLiteralNode(literal: TokenNode(token: tokens[0])),
+                    operator: AssignNode(equal: TokenNode(token: tokens[1])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[2]))
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }

--- a/Tests/ParserTest/BuildTokenTest.swift
+++ b/Tests/ParserTest/BuildTokenTest.swift
@@ -7,7 +7,7 @@ func buildTokens(kinds: [TokenKind]) -> [Token] {
 
     for kind in kinds {
         let start = SourceLocation(line: 1, column: column)
-        column += kind.value.count
+        column += kind.text.count
         let end = SourceLocation(line: 1, column: column)
 
         let token = Token(

--- a/Tests/ParserTest/Control/ForTest.swift
+++ b/Tests/ParserTest/Control/ForTest.swift
@@ -27,17 +27,17 @@ final class ForTest: XCTestCase {
             node,
             BlockItemNode(
                 item: ForStatementNode(
-                    forToken: tokens[0],
-                    parenthesisLeftToken: tokens[1],
-                    pre: IntegerLiteralNode(token: tokens[2]),
-                    firstSemicolonToken: tokens[3],
-                    condition: IntegerLiteralNode(token: tokens[4]),
-                    secondSemicolonToken: tokens[5],
-                    post: IntegerLiteralNode(token: tokens[6]),
-                    parenthesisRightToken: tokens[7],
+                    for: TokenNode(token: tokens[0]),
+                    parenthesisLeft: TokenNode(token: tokens[1]),
+                    pre: IntegerLiteralNode(literal: TokenNode(token: tokens[2])),
+                    firstSemicolon: TokenNode(token: tokens[3]),
+                    condition: IntegerLiteralNode(literal: TokenNode(token: tokens[4])),
+                    secondSemicolon: TokenNode(token: tokens[5]),
+                    post: IntegerLiteralNode(literal: TokenNode(token: tokens[6])),
+                    parenthesisRight: TokenNode(token: tokens[7]),
                     body: BlockItemNode(
-                        item: IntegerLiteralNode(token: tokens[8]),
-                        semicolonToken: tokens[9]
+                        item: IntegerLiteralNode(literal: TokenNode(token: tokens[8])),
+                        semicolon: TokenNode(token: tokens[9])
                     )
                 )
             )
@@ -71,22 +71,22 @@ final class ForTest: XCTestCase {
             node,
             BlockItemNode(
                 item: ForStatementNode(
-                    forToken: tokens[0],
-                    parenthesisLeftToken: tokens[1],
-                    pre: IntegerLiteralNode(token: tokens[2]),
-                    firstSemicolonToken: tokens[3],
-                    condition: IntegerLiteralNode(token: tokens[4]),
-                    secondSemicolonToken: tokens[5],
-                    post: IntegerLiteralNode(token: tokens[6]),
-                    parenthesisRightToken: tokens[7],
+                    for: TokenNode(token: tokens[0]),
+                    parenthesisLeft: TokenNode(token: tokens[1]),
+                    pre: IntegerLiteralNode(literal: TokenNode(token: tokens[2])),
+                    firstSemicolon: TokenNode(token: tokens[3]),
+                    condition: IntegerLiteralNode(literal: TokenNode(token: tokens[4])),
+                    secondSemicolon: TokenNode(token: tokens[5]),
+                    post: IntegerLiteralNode(literal: TokenNode(token: tokens[6])),
+                    parenthesisRight: TokenNode(token: tokens[7]),
                     body: BlockItemNode(
                         item: BlockStatementNode(
-                            braceLeftToken: tokens[8],
+                            braceLeft: TokenNode(token: tokens[8]),
                             items: [
-                                BlockItemNode(item: IntegerLiteralNode(token: tokens[9]), semicolonToken: tokens[10]),
-                                BlockItemNode(item: IntegerLiteralNode(token: tokens[11]), semicolonToken: tokens[12])
+                                BlockItemNode(item: IntegerLiteralNode(literal: TokenNode(token: tokens[9])), semicolon: TokenNode(token: tokens[10])),
+                                BlockItemNode(item: IntegerLiteralNode(literal: TokenNode(token: tokens[11])), semicolon: TokenNode(token: tokens[12]))
                             ],
-                            braceRightToken: tokens[13]
+                            braceRight: TokenNode(token: tokens[13])
                         )
                     )
                 )
@@ -114,17 +114,17 @@ final class ForTest: XCTestCase {
             node,
             BlockItemNode(
                 item: ForStatementNode(
-                    forToken: tokens[0],
-                    parenthesisLeftToken: tokens[1],
+                    for: TokenNode(token: tokens[0]),
+                    parenthesisLeft: TokenNode(token: tokens[1]),
                     pre: nil,
-                    firstSemicolonToken: tokens[2],
+                    firstSemicolon: TokenNode(token: tokens[2]),
                     condition: nil,
-                    secondSemicolonToken: tokens[3],
+                    secondSemicolon: TokenNode(token: tokens[3]),
                     post: nil,
-                    parenthesisRightToken: tokens[4],
+                    parenthesisRight: TokenNode(token: tokens[4]),
                     body: BlockItemNode(
-                        item: IntegerLiteralNode(token: tokens[5]),
-                        semicolonToken: tokens[6]
+                        item: IntegerLiteralNode(literal: TokenNode(token: tokens[5])),
+                        semicolon: TokenNode(token: tokens[6])
                     )
                 )
             )

--- a/Tests/ParserTest/Control/IfTest.swift
+++ b/Tests/ParserTest/Control/IfTest.swift
@@ -23,15 +23,15 @@ final class IfTest: XCTestCase {
             node,
             BlockItemNode(
                 item: IfStatementNode(
-                    ifToken: tokens[0],
-                    parenthesisLeftToken: tokens[1],
-                    condition: IntegerLiteralNode(token: tokens[2]),
-                    parenthesisRightToken: tokens[3],
+                    if: TokenNode(token: tokens[0]),
+                    parenthesisLeft: TokenNode(token: tokens[1]),
+                    condition: IntegerLiteralNode(literal: TokenNode(token: tokens[2])),
+                    parenthesisRight: TokenNode(token: tokens[3]),
                     trueBody: BlockItemNode(
-                        item: IntegerLiteralNode(token: tokens[4]),
-                        semicolonToken: tokens[5]
+                        item: IntegerLiteralNode(literal: TokenNode(token: tokens[4])),
+                        semicolon: TokenNode(token: tokens[5])
                     ),
-                    elseToken: nil,
+                    else: nil,
                     falseBody: nil
                 )
             )
@@ -60,18 +60,18 @@ final class IfTest: XCTestCase {
             node,
             BlockItemNode(
                 item: IfStatementNode(
-                    ifToken: tokens[0],
-                    parenthesisLeftToken: tokens[1],
-                    condition: IntegerLiteralNode(token: tokens[2]),
-                    parenthesisRightToken: tokens[3],
+                    if: TokenNode(token: tokens[0]),
+                    parenthesisLeft: TokenNode(token: tokens[1]),
+                    condition: IntegerLiteralNode(literal: TokenNode(token: tokens[2])),
+                    parenthesisRight: TokenNode(token: tokens[3]),
                     trueBody: BlockItemNode(
-                        item: IntegerLiteralNode(token: tokens[4]),
-                        semicolonToken: tokens[5]
+                        item: IntegerLiteralNode(literal: TokenNode(token: tokens[4])),
+                        semicolon: TokenNode(token: tokens[5])
                     ),
-                    elseToken: tokens[6],
+                    else: TokenNode(token: tokens[6]),
                     falseBody: BlockItemNode(
-                        item: IntegerLiteralNode(token: tokens[7]),
-                        semicolonToken: tokens[8]
+                        item: IntegerLiteralNode(literal: TokenNode(token: tokens[7])),
+                        semicolon: TokenNode(token: tokens[8])
                     )
                 )
             )

--- a/Tests/ParserTest/Control/WhileTest.swift
+++ b/Tests/ParserTest/Control/WhileTest.swift
@@ -23,13 +23,13 @@ final class WhileTest: XCTestCase {
             node,
             BlockItemNode(
                 item: WhileStatementNode(
-                    whileToken: tokens[0],
-                    parenthesisLeftToken: tokens[1],
-                    condition: IntegerLiteralNode(token: tokens[2]),
-                    parenthesisRightToken: tokens[3],
+                    while: TokenNode(token: tokens[0]),
+                    parenthesisLeft: TokenNode(token: tokens[1]),
+                    condition: IntegerLiteralNode(literal: TokenNode(token: tokens[2])),
+                    parenthesisRight: TokenNode(token: tokens[3]),
                     body: BlockItemNode(
-                        item: IntegerLiteralNode(token: tokens[4]),
-                        semicolonToken: tokens[5]
+                        item: IntegerLiteralNode(literal: TokenNode(token: tokens[4])),
+                        semicolon: TokenNode(token: tokens[5])
                     )
                 )
             )

--- a/Tests/ParserTest/FunctionTest.swift
+++ b/Tests/ParserTest/FunctionTest.swift
@@ -29,18 +29,18 @@ final class FunctionTest: XCTestCase {
                 statements: [
                     BlockItemNode(
                         item: FunctionDeclNode(
-                            returnTypeNode: TypeNode(typeToken: tokens[0]),
-                            functionNameToken: tokens[1],
-                            parenthesisLeftToken: tokens[2],
-                            parameterNodes: [],
-                            parenthesisRightToken: tokens[3],
+                            returnType: TypeNode(type: TokenNode(token: tokens[0])),
+                            functionName: TokenNode(token: tokens[1]),
+                            parenthesisLeft: TokenNode(token: tokens[2]),
+                            parameters: [],
+                            parenthesisRight: TokenNode(token: tokens[3]),
                             block: BlockStatementNode(
-                                braceLeftToken: tokens[4],
+                                braceLeft: TokenNode(token: tokens[4]),
                                 items: [
-                                    BlockItemNode(item: IntegerLiteralNode(token: tokens[5]), semicolonToken: tokens[6]),
-                                    BlockItemNode(item: IntegerLiteralNode(token: tokens[7]), semicolonToken: tokens[8]),
+                                    BlockItemNode(item: IntegerLiteralNode(literal: TokenNode(token: tokens[5])), semicolon: TokenNode(token: tokens[6])),
+                                    BlockItemNode(item: IntegerLiteralNode(literal: TokenNode(token: tokens[7])), semicolon: TokenNode(token: tokens[8])),
                                 ],
-                                braceRightToken: tokens[9]
+                                braceRight: TokenNode(token: tokens[9])
                             )
                         )
                     )
@@ -75,18 +75,18 @@ final class FunctionTest: XCTestCase {
                 statements: [
                     BlockItemNode(
                         item: FunctionDeclNode(
-                            returnTypeNode: PointerTypeNode(referenceType: TypeNode(typeToken: tokens[0]), pointerToken: tokens[1]),
-                            functionNameToken: tokens[2],
-                            parenthesisLeftToken: tokens[3],
-                            parameterNodes: [],
-                            parenthesisRightToken: tokens[4],
+                            returnType: PointerTypeNode(referenceType: TypeNode(type: TokenNode(token: tokens[0])), pointer: TokenNode(token: tokens[1])),
+                            functionName: TokenNode(token: tokens[2]),
+                            parenthesisLeft: TokenNode(token: tokens[3]),
+                            parameters: [],
+                            parenthesisRight: TokenNode(token: tokens[4]),
                             block: BlockStatementNode(
-                                braceLeftToken: tokens[5],
+                                braceLeft: TokenNode(token: tokens[5]),
                                 items: [
-                                    BlockItemNode(item: IntegerLiteralNode(token: tokens[6]), semicolonToken: tokens[7]),
-                                    BlockItemNode(item: IntegerLiteralNode(token: tokens[8]), semicolonToken: tokens[9]),
+                                    BlockItemNode(item: IntegerLiteralNode(literal: TokenNode(token: tokens[6])), semicolon: TokenNode(token: tokens[7])),
+                                    BlockItemNode(item: IntegerLiteralNode(literal: TokenNode(token: tokens[8])), semicolon: TokenNode(token: tokens[9])),
                                 ],
-                                braceRightToken: tokens[10]
+                                braceRight: TokenNode(token: tokens[10])
                             )
                         )
                     )
@@ -112,12 +112,12 @@ final class FunctionTest: XCTestCase {
             node,
             BlockItemNode(
                 item: FunctionCallExpressionNode(
-                    identifierToken: tokens[0],
-                    parenthesisLeftToken: tokens[1],
+                    identifier: TokenNode(token: tokens[0]),
+                    parenthesisLeft: TokenNode(token: tokens[1]),
                     arguments: [],
-                    parenthesisRightToken: tokens[2]
+                    parenthesisRight: TokenNode(token: tokens[2])
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }
@@ -150,20 +150,20 @@ final class FunctionTest: XCTestCase {
                 statements: [
                     BlockItemNode(
                         item: FunctionDeclNode(
-                            returnTypeNode: TypeNode(typeToken: tokens[0]),
-                            functionNameToken: tokens[1],
-                            parenthesisLeftToken: tokens[2],
-                            parameterNodes: [
-                                FunctionParameterNode(type: TypeNode(typeToken: tokens[3]), identifierToken: tokens[4], commaToken: tokens[5]),
-                                FunctionParameterNode(type: TypeNode(typeToken: tokens[6]), identifierToken: tokens[7])
+                            returnType: TypeNode(type: TokenNode(token: tokens[0])),
+                            functionName: TokenNode(token: tokens[1]),
+                            parenthesisLeft: TokenNode(token: tokens[2]),
+                            parameters: [
+                                FunctionParameterNode(type: TypeNode(type: TokenNode(token: tokens[3])), identifier: TokenNode(token: tokens[4]), comma: TokenNode(token: tokens[5])),
+                                FunctionParameterNode(type: TypeNode(type: TokenNode(token: tokens[6])), identifier: TokenNode(token: tokens[7]))
                             ],
-                            parenthesisRightToken: tokens[8],
+                            parenthesisRight: TokenNode(token: tokens[8]),
                             block: BlockStatementNode(
-                                braceLeftToken: tokens[9],
+                                braceLeft: TokenNode(token: tokens[9]),
                                 items: [
-                                    BlockItemNode(item: IntegerLiteralNode(token: tokens[10]), semicolonToken: tokens[11]),
+                                    BlockItemNode(item: IntegerLiteralNode(literal: TokenNode(token: tokens[10])), semicolon: TokenNode(token: tokens[11])),
                                 ],
-                                braceRightToken: tokens[12]
+                                braceRight: TokenNode(token: tokens[12])
                             )
                         )
                     )
@@ -192,18 +192,18 @@ final class FunctionTest: XCTestCase {
             node,
             BlockItemNode(
                 item: FunctionCallExpressionNode(
-                    identifierToken: tokens[0],
-                    parenthesisLeftToken: tokens[1],
+                    identifier: TokenNode(token: tokens[0]),
+                    parenthesisLeft: TokenNode(token: tokens[1]),
                     arguments: [
                         ExpressionListItemNode(
-                            expression: IntegerLiteralNode(token: tokens[2]),
-                            comma: tokens[3]
+                            expression: IntegerLiteralNode(literal: TokenNode(token: tokens[2])),
+                            comma: TokenNode(token: tokens[3])
                         ),
-                        ExpressionListItemNode(expression: IdentifierNode(token: tokens[4]))
+                        ExpressionListItemNode(expression: IdentifierNode(baseName: TokenNode(token: tokens[4])))
                     ],
-                    parenthesisRightToken: tokens[5]
+                    parenthesisRight: TokenNode(token: tokens[5])
                 ),
-                semicolonToken: tokens[6]
+                semicolon: TokenNode(token: tokens[6])
             )
         )
     }
@@ -239,33 +239,33 @@ final class FunctionTest: XCTestCase {
                 statements: [
                     BlockItemNode(
                         item: FunctionDeclNode(
-                            returnTypeNode: TypeNode(typeToken: tokens[0]),
-                            functionNameToken: tokens[1],
-                            parenthesisLeftToken: tokens[2],
-                            parameterNodes: [],
-                            parenthesisRightToken: tokens[3],
+                            returnType: TypeNode(type: TokenNode(token: tokens[0])),
+                            functionName: TokenNode(token: tokens[1]),
+                            parenthesisLeft: TokenNode(token: tokens[2]),
+                            parameters: [],
+                            parenthesisRight: TokenNode(token: tokens[3]),
                             block: BlockStatementNode(
-                                braceLeftToken: tokens[4],
+                                braceLeft: TokenNode(token: tokens[4]),
                                 items: [
-                                    BlockItemNode(item: IntegerLiteralNode(token: tokens[5]), semicolonToken: tokens[6])
+                                    BlockItemNode(item: IntegerLiteralNode(literal: TokenNode(token: tokens[5])), semicolon: TokenNode(token: tokens[6]))
                                 ],
-                                braceRightToken: tokens[7]
+                                braceRight: TokenNode(token: tokens[7])
                             )
                         )
                     ),
                     BlockItemNode(
                         item: FunctionDeclNode(
-                            returnTypeNode: TypeNode(typeToken: tokens[8]),
-                            functionNameToken: tokens[9],
-                            parenthesisLeftToken: tokens[10],
-                            parameterNodes: [],
-                            parenthesisRightToken: tokens[11],
+                            returnType: TypeNode(type: TokenNode(token: tokens[8])),
+                            functionName: TokenNode(token: tokens[9]),
+                            parenthesisLeft: TokenNode(token: tokens[10]),
+                            parameters: [],
+                            parenthesisRight: TokenNode(token: tokens[11]),
                             block: BlockStatementNode(
-                                braceLeftToken: tokens[12],
+                                braceLeft: TokenNode(token: tokens[12]),
                                 items: [
-                                    BlockItemNode(item: IntegerLiteralNode(token: tokens[13]), semicolonToken: tokens[14])
+                                    BlockItemNode(item: IntegerLiteralNode(literal: TokenNode(token: tokens[13])), semicolon: TokenNode(token: tokens[14]))
                                 ],
-                                braceRightToken: tokens[15]
+                                braceRight: TokenNode(token: tokens[15])
                             )
                         )
                     )
@@ -292,12 +292,12 @@ final class FunctionTest: XCTestCase {
             node,
             BlockItemNode(
                 item: SubscriptCallExpressionNode(
-                    identifierNode: IdentifierNode(token: tokens[0]),
-                    squareLeftToken: tokens[1],
-                    argument: IntegerLiteralNode(token: tokens[2]),
-                    squareRightToken: tokens[3]
+                    identifier: IdentifierNode(baseName: TokenNode(token: tokens[0])),
+                    squareLeft: TokenNode(token: tokens[1]),
+                    argument: IntegerLiteralNode(literal: TokenNode(token: tokens[2])),
+                    squareRight: TokenNode(token: tokens[3])
                 ),
-                semicolonToken: tokens[4]
+                semicolon: TokenNode(token: tokens[4])
             )
         )
     }
@@ -322,16 +322,16 @@ final class FunctionTest: XCTestCase {
             node,
             BlockItemNode(
                 item: SubscriptCallExpressionNode(
-                    identifierNode: IdentifierNode(token: tokens[0]),
-                    squareLeftToken: tokens[1],
+                    identifier: IdentifierNode(baseName: TokenNode(token: tokens[0])),
+                    squareLeft: TokenNode(token: tokens[1]),
                     argument: InfixOperatorExpressionNode(
-                        left: IntegerLiteralNode(token: tokens[2]),
-                        operator: BinaryOperatorNode(token: tokens[3]),
-                        right: IdentifierNode(token: tokens[4])
+                        left: IntegerLiteralNode(literal: TokenNode(token: tokens[2])),
+                        operator: BinaryOperatorNode(operator: TokenNode(token: tokens[3])),
+                        right: IdentifierNode(baseName: TokenNode(token: tokens[4]))
                     ),
-                    squareRightToken: tokens[5]
+                    squareRight: TokenNode(token: tokens[5])
                 ),
-                semicolonToken: tokens[6]
+                semicolon: TokenNode(token: tokens[6])
             )
         )
     }

--- a/Tests/ParserTest/OperatorPriorityTest.swift
+++ b/Tests/ParserTest/OperatorPriorityTest.swift
@@ -24,14 +24,14 @@ final class OperatorPriorityTest: XCTestCase {
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
                     left: InfixOperatorExpressionNode(
-                        left: IntegerLiteralNode(token: tokens[0]),
-                        operator: BinaryOperatorNode(token: tokens[1]),
-                        right: IntegerLiteralNode(token: tokens[2])
+                        left: IntegerLiteralNode(literal: TokenNode(token: tokens[0])),
+                        operator: BinaryOperatorNode(operator: TokenNode(token: tokens[1])),
+                        right: IntegerLiteralNode(literal: TokenNode(token: tokens[2]))
                     ),
-                    operator: BinaryOperatorNode(token: tokens[3]),
-                    right: IntegerLiteralNode(token: tokens[4])
+                    operator: BinaryOperatorNode(operator: TokenNode(token: tokens[3])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[4]))
                 ),
-                semicolonToken: tokens[5]
+                semicolon: TokenNode(token: tokens[5])
             )
         )
     }
@@ -56,14 +56,14 @@ final class OperatorPriorityTest: XCTestCase {
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
                     left: InfixOperatorExpressionNode(
-                        left: IntegerLiteralNode(token: tokens[0]),
-                        operator: BinaryOperatorNode(token: tokens[1]),
-                        right: IntegerLiteralNode(token: tokens[2])
+                        left: IntegerLiteralNode(literal: TokenNode(token: tokens[0])),
+                        operator: BinaryOperatorNode(operator: TokenNode(token: tokens[1])),
+                        right: IntegerLiteralNode(literal: TokenNode(token: tokens[2]))
                     ),
-                    operator: BinaryOperatorNode(token: tokens[3]),
-                    right: IntegerLiteralNode(token: tokens[4])
+                    operator: BinaryOperatorNode(operator: TokenNode(token: tokens[3])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[4]))
                 ),
-                semicolonToken: tokens[5]
+                semicolon: TokenNode(token: tokens[5])
             )
         )
     }
@@ -87,15 +87,15 @@ final class OperatorPriorityTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[0]),
-                    operator: BinaryOperatorNode(token: tokens[1]),
+                    left: IntegerLiteralNode(literal: TokenNode(token: tokens[0])),
+                    operator: BinaryOperatorNode(operator: TokenNode(token: tokens[1])),
                     right: InfixOperatorExpressionNode(
-                        left: IntegerLiteralNode(token: tokens[2]),
-                        operator: BinaryOperatorNode(token: tokens[3]),
-                        right: IntegerLiteralNode(token: tokens[4])
+                        left: IntegerLiteralNode(literal: TokenNode(token: tokens[2])),
+                        operator: BinaryOperatorNode(operator: TokenNode(token: tokens[3])),
+                        right: IntegerLiteralNode(literal: TokenNode(token: tokens[4]))
                     )
                 ),
-                semicolonToken: tokens[5]
+                semicolon: TokenNode(token: tokens[5])
             )
         )
     }
@@ -122,18 +122,18 @@ final class OperatorPriorityTest: XCTestCase {
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
                     left: TupleExpressionNode(
-                        parenthesisLeftToken: tokens[0],
+                        parenthesisLeft: TokenNode(token: tokens[0]),
                         expression: InfixOperatorExpressionNode(
-                            left: IntegerLiteralNode(token: tokens[1]),
-                            operator: BinaryOperatorNode(token: tokens[2]),
-                            right: IntegerLiteralNode(token: tokens[3])
+                            left: IntegerLiteralNode(literal: TokenNode(token: tokens[1])),
+                            operator: BinaryOperatorNode(operator: TokenNode(token: tokens[2])),
+                            right: IntegerLiteralNode(literal: TokenNode(token: tokens[3]))
                         ),
-                        parenthesisRightToken: tokens[4]
+                        parenthesisRight: TokenNode(token: tokens[4])
                     ),
-                    operator: BinaryOperatorNode(token: tokens[5]),
-                    right: IntegerLiteralNode(token: tokens[6])
+                    operator: BinaryOperatorNode(operator: TokenNode(token: tokens[5])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[6]))
                 ),
-                semicolonToken: tokens[7]
+                semicolon: TokenNode(token: tokens[7])
             )
         )
     }

--- a/Tests/ParserTest/OperatorsTest.swift
+++ b/Tests/ParserTest/OperatorsTest.swift
@@ -21,11 +21,11 @@ final class OperatorsTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[0]),
-                    operator: BinaryOperatorNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[2])
+                    left: IntegerLiteralNode(literal: TokenNode(token: tokens[0])),
+                    operator: BinaryOperatorNode(operator: TokenNode(token: tokens[1])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[2]))
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }
@@ -47,11 +47,11 @@ final class OperatorsTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[0]),
-                    operator: BinaryOperatorNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[2])
+                    left: IntegerLiteralNode(literal: TokenNode(token: tokens[0])),
+                    operator: BinaryOperatorNode(operator: TokenNode(token: tokens[1])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[2]))
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }
@@ -73,11 +73,11 @@ final class OperatorsTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[0]),
-                    operator: BinaryOperatorNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[2])
+                    left: IntegerLiteralNode(literal: TokenNode(token: tokens[0])),
+                    operator: BinaryOperatorNode(operator: TokenNode(token: tokens[1])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[2]))
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }
@@ -99,11 +99,11 @@ final class OperatorsTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[0]),
-                    operator: BinaryOperatorNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[2])
+                    left: IntegerLiteralNode(literal: TokenNode(token: tokens[0])),
+                    operator: BinaryOperatorNode(operator: TokenNode(token: tokens[1])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[2]))
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }
@@ -124,10 +124,10 @@ final class OperatorsTest: XCTestCase {
             node,
             BlockItemNode(
                 item: PrefixOperatorExpressionNode(
-                    operator: tokens[0],
-                    expression: IntegerLiteralNode(token: tokens[1])
+                    operator: TokenNode(token: tokens[0]),
+                    expression: IntegerLiteralNode(literal: TokenNode(token: tokens[1]))
                 ),
-                semicolonToken: tokens[2]
+                semicolon: TokenNode(token: tokens[2])
             )
         )
     }
@@ -148,10 +148,10 @@ final class OperatorsTest: XCTestCase {
             node,
             BlockItemNode(
                 item: PrefixOperatorExpressionNode(
-                    operator: tokens[0],
-                    expression: IntegerLiteralNode(token: tokens[1])
+                    operator: TokenNode(token: tokens[0]),
+                    expression: IntegerLiteralNode(literal: TokenNode(token: tokens[1]))
                 ),
-                semicolonToken: tokens[2]
+                semicolon: TokenNode(token: tokens[2])
             )
         )
     }
@@ -172,10 +172,10 @@ final class OperatorsTest: XCTestCase {
             node,
             BlockItemNode(
                 item: PrefixOperatorExpressionNode(
-                    operator: tokens[0],
-                    expression: IdentifierNode(token: tokens[1])
+                    operator: TokenNode(token: tokens[0]),
+                    expression: IdentifierNode(baseName: TokenNode(token: tokens[1]))
                 ),
-                semicolonToken: tokens[2]
+                semicolon: TokenNode(token: tokens[2])
             )
         )
     }
@@ -196,10 +196,10 @@ final class OperatorsTest: XCTestCase {
             node,
             BlockItemNode(
                 item: PrefixOperatorExpressionNode(
-                    operator: tokens[0],
-                    expression: IdentifierNode(token: tokens[1])
+                    operator: TokenNode(token: tokens[0]),
+                    expression: IdentifierNode(baseName: TokenNode(token: tokens[1]))
                 ),
-                semicolonToken: tokens[2]
+                semicolon: TokenNode(token: tokens[2])
             )
         )
     }
@@ -221,11 +221,11 @@ final class OperatorsTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[0]),
-                    operator: BinaryOperatorNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[2])
+                    left: IntegerLiteralNode(literal: TokenNode(token: tokens[0])),
+                    operator: BinaryOperatorNode(operator: TokenNode(token: tokens[1])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[2]))
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }
@@ -247,11 +247,11 @@ final class OperatorsTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[0]),
-                    operator: BinaryOperatorNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[2])
+                    left: IntegerLiteralNode(literal: TokenNode(token: tokens[0])),
+                    operator: BinaryOperatorNode(operator: TokenNode(token: tokens[1])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[2]))
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }
@@ -273,11 +273,11 @@ final class OperatorsTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[0]),
-                    operator: BinaryOperatorNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[2])
+                    left: IntegerLiteralNode(literal: TokenNode(token: tokens[0])),
+                    operator: BinaryOperatorNode(operator: TokenNode(token: tokens[1])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[2]))
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }
@@ -299,11 +299,11 @@ final class OperatorsTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[0]),
-                    operator: BinaryOperatorNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[2])
+                    left: IntegerLiteralNode(literal: TokenNode(token: tokens[0])),
+                    operator: BinaryOperatorNode(operator: TokenNode(token: tokens[1])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[2]))
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }
@@ -325,11 +325,11 @@ final class OperatorsTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[0]),
-                    operator: BinaryOperatorNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[2])
+                    left: IntegerLiteralNode(literal: TokenNode(token: tokens[0])),
+                    operator: BinaryOperatorNode(operator: TokenNode(token: tokens[1])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[2]))
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }
@@ -351,11 +351,11 @@ final class OperatorsTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IntegerLiteralNode(token: tokens[0]),
-                    operator: BinaryOperatorNode(token: tokens[1]),
-                    right: IntegerLiteralNode(token: tokens[2])
+                    left: IntegerLiteralNode(literal: TokenNode(token: tokens[0])),
+                    operator: BinaryOperatorNode(operator: TokenNode(token: tokens[1])),
+                    right: IntegerLiteralNode(literal: TokenNode(token: tokens[2]))
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }
@@ -376,8 +376,16 @@ final class OperatorsTest: XCTestCase {
         XCTAssertEqual(
             node,
             BlockItemNode(
-                item: IntegerLiteralNode(token: Token(kind: .number("8"), sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 1)))),
-                semicolonToken: tokens[4]
+                item: IntegerLiteralNode(
+                    literal: TokenNode(token: Token(
+                        kind: .number("8"),
+                        sourceRange: SourceRange(
+                            start: SourceLocation(line: 1, column: 1),
+                            end: SourceLocation(line: 1, column: 1)
+                        )
+                    ))
+                ),
+                semicolon: TokenNode(token: tokens[4])
             )
         )
     }

--- a/Tests/ParserTest/ReturnTest.swift
+++ b/Tests/ParserTest/ReturnTest.swift
@@ -20,10 +20,10 @@ final class ReturnTest: XCTestCase {
             node,
             BlockItemNode(
                 item: ReturnStatementNode(
-                    returnToken: tokens[0],
-                    expression: IntegerLiteralNode(token: tokens[1])
+                    return: TokenNode(token: tokens[0]),
+                    expression: IntegerLiteralNode(literal: TokenNode(token: tokens[1]))
                 ),
-                semicolonToken: tokens[2]
+                semicolon: TokenNode(token: tokens[2])
             )
         )
     }

--- a/Tests/ParserTest/StringLiteralTest.swift
+++ b/Tests/ParserTest/StringLiteralTest.swift
@@ -18,8 +18,8 @@ final class StringLiteralTest: XCTestCase {
         XCTAssertEqual(
             node,
             BlockItemNode(
-                item: StringLiteralNode(token: tokens[0]),
-                semicolonToken: tokens[1]
+                item: StringLiteralNode(literal: TokenNode(token: tokens[0])),
+                semicolon: TokenNode(token: tokens[1])
             )
         )
     }
@@ -41,11 +41,11 @@ final class StringLiteralTest: XCTestCase {
             node,
             BlockItemNode(
                 item: InfixOperatorExpressionNode(
-                    left: IdentifierNode(token: tokens[0]),
-                    operator: AssignNode(token: tokens[1]),
-                    right: StringLiteralNode(token: tokens[2])
+                    left: IdentifierNode(baseName: TokenNode(token: tokens[0])),
+                    operator: AssignNode(equal: TokenNode(token: tokens[1])),
+                    right: StringLiteralNode(literal: TokenNode(token: tokens[2]))
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }

--- a/Tests/ParserTest/VariableTest.swift
+++ b/Tests/ParserTest/VariableTest.swift
@@ -20,10 +20,10 @@ final class VariableTest: XCTestCase {
             node,
             BlockItemNode(
                 item: VariableDeclNode(
-                    type: TypeNode(typeToken: tokens[0]),
-                    identifierToken: tokens[1]
+                    type: TypeNode(type: TokenNode(token: tokens[0])),
+                    identifier: TokenNode(token: tokens[1])
                 ),
-                semicolonToken: tokens[2]
+                semicolon: TokenNode(token: tokens[2])
             )
         )
     }
@@ -46,12 +46,12 @@ final class VariableTest: XCTestCase {
             node,
             BlockItemNode(
                 item: VariableDeclNode(
-                    type: TypeNode(typeToken: tokens[0]),
-                    identifierToken: tokens[1],
-                    initializerToken: tokens[2],
-                    initializerExpr: IntegerLiteralNode(token: tokens[3])
+                    type: TypeNode(type: TokenNode(token: tokens[0])),
+                    identifier: TokenNode(token: tokens[1]),
+                    equal: TokenNode(token: tokens[2]),
+                    initializerExpr: IntegerLiteralNode(literal: TokenNode(token: tokens[3]))
                 ),
-                semicolonToken: tokens[4]
+                semicolon: TokenNode(token: tokens[4])
             )
         )
     }
@@ -74,12 +74,12 @@ final class VariableTest: XCTestCase {
             BlockItemNode(
                 item: VariableDeclNode(
                     type: PointerTypeNode(
-                        referenceType: TypeNode(typeToken: tokens[0]),
-                        pointerToken: tokens[1]
+                        referenceType: TypeNode(type: TokenNode(token: tokens[0])),
+                        pointer: TokenNode(token: tokens[1])
                     ),
-                    identifierToken: tokens[2]
+                    identifier: TokenNode(token: tokens[2])
                 ),
-                semicolonToken: tokens[3]
+                semicolon: TokenNode(token: tokens[3])
             )
         )
     }
@@ -104,14 +104,14 @@ final class VariableTest: XCTestCase {
                 item: VariableDeclNode(
                     type: PointerTypeNode(
                         referenceType: PointerTypeNode(
-                            referenceType: TypeNode(typeToken: tokens[0]),
-                            pointerToken: tokens[1]
+                            referenceType: TypeNode(type: TokenNode(token: tokens[0])),
+                            pointer: TokenNode(token: tokens[1])
                         ),
-                        pointerToken: tokens[2]
+                        pointer: TokenNode(token: tokens[2])
                     ),
-                    identifierToken: tokens[3]
+                    identifier: TokenNode(token: tokens[3])
                 ),
-                semicolonToken: tokens[4]
+                semicolon: TokenNode(token: tokens[4])
             )
         )
     }
@@ -135,14 +135,14 @@ final class VariableTest: XCTestCase {
             BlockItemNode(
                 item: VariableDeclNode(
                     type: ArrayTypeNode(
-                        elementType: TypeNode(typeToken: tokens[0]),
-                        squareLeftToken: tokens[2],
-                        arraySizeToken: tokens[3],
-                        squareRightToken: tokens[4]
+                        elementType: TypeNode(type: TokenNode(token: tokens[0])),
+                        squareLeft: TokenNode(token: tokens[2]),
+                        arraySize: TokenNode(token: tokens[3]),
+                        squareRight: TokenNode(token: tokens[4])
                     ),
-                    identifierToken: tokens[1]
+                    identifier: TokenNode(token: tokens[1])
                 ),
-                semicolonToken: tokens[5]
+                semicolon: TokenNode(token: tokens[5])
             )
         )
     }
@@ -172,23 +172,23 @@ final class VariableTest: XCTestCase {
             BlockItemNode(
                 item: VariableDeclNode(
                     type: ArrayTypeNode(
-                        elementType: TypeNode(typeToken: tokens[0]),
-                        squareLeftToken: tokens[2],
-                        arraySizeToken: tokens[3],
-                        squareRightToken: tokens[4]
+                        elementType: TypeNode(type: TokenNode(token: tokens[0])),
+                        squareLeft: TokenNode(token: tokens[2]),
+                        arraySize: TokenNode(token: tokens[3]),
+                        squareRight: TokenNode(token: tokens[4])
                     ),
-                    identifierToken: tokens[1],
-                    initializerToken: tokens[5],
+                    identifier: TokenNode(token: tokens[1]),
+                    equal: TokenNode(token: tokens[5]),
                     initializerExpr: ArrayExpressionNode(
-                        braceLeft: tokens[6],
+                        braceLeft: TokenNode(token: tokens[6]),
                         exprListNodes: [
-                            ExpressionListItemNode(expression: IntegerLiteralNode(token: tokens[7]), comma: tokens[8]),
-                            ExpressionListItemNode(expression: IntegerLiteralNode(token: tokens[9]))
+                            ExpressionListItemNode(expression: IntegerLiteralNode(literal: TokenNode(token: tokens[7])), comma: TokenNode(token: tokens[8])),
+                            ExpressionListItemNode(expression: IntegerLiteralNode(literal: TokenNode(token: tokens[9])))
                         ],
-                        braceRight: tokens[10]
+                        braceRight: TokenNode(token: tokens[10])
                     )
                 ),
-                semicolonToken: tokens[11]
+                semicolon: TokenNode(token: tokens[11])
             )
         )
     }
@@ -214,16 +214,16 @@ final class VariableTest: XCTestCase {
             BlockItemNode(
                 item: VariableDeclNode(
                     type: ArrayTypeNode(
-                        elementType: TypeNode(typeToken: tokens[0]),
-                        squareLeftToken: tokens[2],
-                        arraySizeToken: tokens[3],
-                        squareRightToken: tokens[4]
+                        elementType: TypeNode(type: TokenNode(token: tokens[0])),
+                        squareLeft: TokenNode(token: tokens[2]),
+                        arraySize: TokenNode(token: tokens[3]),
+                        squareRight: TokenNode(token: tokens[4])
                     ),
-                    identifierToken: tokens[1],
-                    initializerToken: tokens[5],
-                    initializerExpr: StringLiteralNode(token: tokens[6])
+                    identifier: TokenNode(token: tokens[1]),
+                    equal: TokenNode(token: tokens[5]),
+                    initializerExpr: StringLiteralNode(literal: TokenNode(token: tokens[6]))
                 ),
-                semicolonToken: tokens[7]
+                semicolon: TokenNode(token: tokens[7])
             )
         )
     }
@@ -248,14 +248,14 @@ final class VariableTest: XCTestCase {
             BlockItemNode(
                 item: VariableDeclNode(
                     type: ArrayTypeNode(
-                        elementType: PointerTypeNode(referenceType: TypeNode(typeToken: tokens[0]), pointerToken: tokens[1]),
-                        squareLeftToken: tokens[3],
-                        arraySizeToken: tokens[4],
-                        squareRightToken: tokens[5]
+                        elementType: PointerTypeNode(referenceType: TypeNode(type: TokenNode(token: tokens[0])), pointer: TokenNode(token: tokens[1])),
+                        squareLeft: TokenNode(token: tokens[3]),
+                        arraySize: TokenNode(token: tokens[4]),
+                        squareRight: TokenNode(token: tokens[5])
                     ),
-                    identifierToken: tokens[2]
+                    identifier: TokenNode(token: tokens[2])
                 ),
-                semicolonToken: tokens[6]
+                semicolon: TokenNode(token: tokens[6])
             )
         )
     }
@@ -278,10 +278,10 @@ final class VariableTest: XCTestCase {
                 statements: [
                     BlockItemNode(
                         item: VariableDeclNode(
-                            type: TypeNode(typeToken: tokens[0]),
-                            identifierToken: tokens[1]
+                            type: TypeNode(type: TokenNode(token: tokens[0])),
+                            identifier: TokenNode(token: tokens[1])
                         ),
-                        semicolonToken: tokens[2]
+                        semicolon: TokenNode(token: tokens[2])
                     )
                 ]
             )
@@ -308,12 +308,12 @@ final class VariableTest: XCTestCase {
                     BlockItemNode(
                         item: VariableDeclNode(
                             type: PointerTypeNode(
-                                referenceType: TypeNode(typeToken: tokens[0]),
-                                pointerToken: tokens[1]
+                                referenceType: TypeNode(type: TokenNode(token: tokens[0])),
+                                pointer: TokenNode(token: tokens[1])
                             ),
-                            identifierToken: tokens[2]
+                            identifier: TokenNode(token: tokens[2])
                         ),
-                        semicolonToken: tokens[3]
+                        semicolon: TokenNode(token: tokens[3])
                     )
                 ]
             )

--- a/Tests/TokenizerTest/StringLiteralTest.swift
+++ b/Tests/TokenizerTest/StringLiteralTest.swift
@@ -7,8 +7,7 @@ final class StringLiteralTest: XCTestCase {
         let source = "\"aaaa\""
         let tokens = try Tokenizer(source: source).tokenize()
 
-        // FIXME: StringLiteralの両端のクオーテーションをどうするか
-        XCTAssertEqual(tokens.reduce("") { $0 + $1.description }, "aaaa")
+        XCTAssertEqual(tokens.reduce("") { $0 + $1.description }, source)
         XCTAssertEqual(
             tokens,
             [


### PR DESCRIPTION
# 概要
NodeはTokenを直接もたずTokenNodeを持つようにする

メリット
- TokenNodeをTokenを持つ葉Nodeとして扱い、葉以外がTokenを持たないため構造が明確になる
- sourceTokensを`children.map { $0.sourceTokens }` で計算できる
    - TokenNodeだけ `[token]`
    - sourceTokensのテストを書けば、childrenに漏れがないことも検証できる

デメリット
- やや冗長になる