### PR TITLE
CSTにsizeofのNodeを作る

### DIFF
--- a/Sources/Generator/Generator.swift
+++ b/Sources/Generator/Generator.swift
@@ -591,6 +591,12 @@ public final class Generator {
                 } else {
                     throw GenerateError.invalidSyntax(location: node.sourceTokens[0].sourceRange.start)
                 }
+
+            case .sizeof:
+                // FIXME: どうやって式の型を推測する？
+                // 今はとりあえず固定で8
+                result += "    mov x0, #8\n"
+                result += "    str x0, [sp, #-16]!\n"
             }
 
             return result

--- a/Sources/Parser/Node/ExpressionNode.swift
+++ b/Sources/Parser/Node/ExpressionNode.swift
@@ -36,6 +36,9 @@ public class PrefixOperatorExpressionNode: NodeProtocol {
 
         /// `&`
         case address
+
+        /// `sizeof`
+        case sizeof
     }
 
     // MARK: - Property
@@ -61,6 +64,9 @@ public class PrefixOperatorExpressionNode: NodeProtocol {
 
         case .reserved(.and):
             return .address
+
+        case .keyword(.sizeof):
+            return .sizeof
 
         default:
             fatalError()

--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -614,12 +614,10 @@ public final class Parser {
 
         switch tokens[index].kind {
         case .keyword(.sizeof):
-            try consumeKeywordToken(.sizeof)
-
-            _ = try unary()
-
-            // FIXME: どうやって式の型を判断する？
-            return IntegerLiteralNode(literal: TokenNode(token: Token(kind: .number("8"), sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))))
+            return PrefixOperatorExpressionNode(
+                operator: try consumeKeywordToken(.sizeof),
+                expression: try unary()
+            )
 
         case .reserved(.add):
             return PrefixOperatorExpressionNode(

--- a/Tests/ParserTest/OperatorsTest.swift
+++ b/Tests/ParserTest/OperatorsTest.swift
@@ -373,17 +373,18 @@ final class OperatorsTest: XCTestCase {
         )
         let node = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(node.sourceTokens, tokens)
+
         XCTAssertEqual(
             node,
             BlockItemNode(
-                item: IntegerLiteralNode(
-                    literal: TokenNode(token: Token(
-                        kind: .number("8"),
-                        sourceRange: SourceRange(
-                            start: SourceLocation(line: 1, column: 1),
-                            end: SourceLocation(line: 1, column: 1)
-                        )
-                    ))
+                item: PrefixOperatorExpressionNode(
+                    operator: TokenNode(token: tokens[0]),
+                    expression: TupleExpressionNode(
+                        parenthesisLeft: TokenNode(token: tokens[1]),
+                        expression: IntegerLiteralNode(literal: TokenNode(token: tokens[2])),
+                        parenthesisRight: TokenNode(token: tokens[3])
+                    )
                 ),
                 semicolon: TokenNode(token: tokens[4])
             )


### PR DESCRIPTION
# 概要
- sizeofをPrefixOperatorNodeとして表現
    - sizeofをCSTの段階で`IntegerLiteral`に置き換えていたが、clangではsizeofのASTが生成されていたため

# 実装

- 配列のsizeofなどは未実装で8を固定値として生成
    - 未だCSTのExprから、その型を判別する実装をしていないため