### PR TITLE
EOF Tokenを導入する

### DIFF
--- a/Sources/Parser/Node/StatementNode.swift
+++ b/Sources/Parser/Node/StatementNode.swift
@@ -255,14 +255,16 @@ public class SourceFileNode: NodeProtocol {
 
     public let kind: NodeKind = .sourceFile
     public var children: [any NodeProtocol] {
-        statements
+        statements + [endOfFile]
     }
 
     public let statements: [BlockItemNode]
+    public let endOfFile: TokenNode
 
     // MARK: - Initializer
 
-    public init(statements: [BlockItemNode]) {
+    public init(statements: [BlockItemNode], endOfFile: TokenNode) {
         self.statements = statements
+        self.endOfFile = endOfFile
     }
 }

--- a/Sources/Tokenizer/Token.swift
+++ b/Sources/Tokenizer/Token.swift
@@ -72,6 +72,8 @@ public enum TokenKind: Equatable {
     case identifier(_ value: String)
     case type(_ kind: TypeKind)
 
+    case endOfFile
+
     public var text: String {
         switch self {
         case .reserved(let kind):
@@ -91,6 +93,9 @@ public enum TokenKind: Equatable {
 
         case .type(let kind):
             return kind.rawValue
+
+        case .endOfFile:
+            return ""
         }
     }
 

--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -33,8 +33,6 @@ public class Tokenizer {
 
         while index < charactors.count {
             let leadingTrivia = extractTrivia(untilBeforeNewLine: false)
-            // FIXME: triviaで終わっていたら無視, EOF TokenのleadingTriviaにして解決すべき
-            guard index < charactors.count else { break }
 
             // sourceLocationにtriviaは含まない
             let startLocation = currentSourceLocation
@@ -50,6 +48,10 @@ public class Tokenizer {
                 sourceRange: SourceRange(start: startLocation, end: endLocation)
             )
             tokens.append(token)
+        }
+
+        if let lastToken = tokens.last, lastToken.kind != .endOfFile {
+            tokens.append(Token(kind: .endOfFile, sourceRange: SourceRange(start: currentSourceLocation, end: currentSourceLocation)))
         }
 
         return tokens
@@ -139,7 +141,7 @@ public class Tokenizer {
                     index += 1
                 }
 
-                if !untilBeforeNewLine {
+                if index < charactors.count, !untilBeforeNewLine {
                     result.append(charactors[index])
                     index += 1
                 }
@@ -173,6 +175,10 @@ public class Tokenizer {
     private let typeKinds = TokenKind.TypeKind.allCases.sorted { $0.rawValue.count > $1.rawValue.count }
 
     private func extractTokenKind() throws -> TokenKind {
+        if index >= charactors.count {
+            return .endOfFile
+        }
+
         if charactors[index].isNumber {
             return extractNumber()
         }

--- a/Tests/CCompilerCoreTest/CompileErrorTest.swift
+++ b/Tests/CCompilerCoreTest/CompileErrorTest.swift
@@ -48,7 +48,7 @@ final class CompileErrorTest: XCTestCase {
         do {
             _ = try compile("int main(){a = 0;}")
         } catch let error as CompileError {
-            XCTAssertEqual(error, .invalidSyntax(location: SourceLocation(line: 1, column: 19)))
+            XCTAssertEqual(error, .noSuchVariable(variableName: "a", location: SourceLocation(line: 1, column: 12)))
         }
     }
 }

--- a/Tests/CCompilerCoreTest/CompileErrorTest.swift
+++ b/Tests/CCompilerCoreTest/CompileErrorTest.swift
@@ -48,7 +48,7 @@ final class CompileErrorTest: XCTestCase {
         do {
             _ = try compile("int main(){a = 0;}")
         } catch let error as CompileError {
-            XCTAssertEqual(error, .noSuchVariable(variableName: "a", location: SourceLocation(line: 1, column: 12)))
+            XCTAssertEqual(error, .invalidSyntax(location: SourceLocation(line: 1, column: 19)))
         }
     }
 }

--- a/Tests/ParserTest/Control/ForTest.swift
+++ b/Tests/ParserTest/Control/ForTest.swift
@@ -60,7 +60,7 @@ final class ForTest: XCTestCase {
                 .reserved(.semicolon),
                 .number("5"),
                 .reserved(.semicolon),
-                .reserved(.braceRight),
+                .reserved(.braceRight)
             ]
         )
         let node = try Parser(tokens: tokens).stmt()

--- a/Tests/ParserTest/Control/IfTest.swift
+++ b/Tests/ParserTest/Control/IfTest.swift
@@ -12,12 +12,13 @@ final class IfTest: XCTestCase {
                 .number("1"),
                 .reserved(.parenthesisRight),
                 .number("2"),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
 
-        XCTAssertEqual(node.sourceTokens, tokens)
+        XCTAssertEqual(node.sourceTokens, tokens.dropLast())
 
         XCTAssertEqual(
             node,
@@ -49,12 +50,13 @@ final class IfTest: XCTestCase {
                 .reserved(.semicolon),
                 .keyword(.else),
                 .number("3"),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
 
-        XCTAssertEqual(node.sourceTokens, tokens)
+        XCTAssertEqual(node.sourceTokens, tokens.dropLast())
 
         XCTAssertEqual(
             node,

--- a/Tests/ParserTest/Control/WhileTest.swift
+++ b/Tests/ParserTest/Control/WhileTest.swift
@@ -12,12 +12,13 @@ final class WhileTest: XCTestCase {
                 .number("1"),
                 .reserved(.parenthesisRight),
                 .number("2"),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
 
-        XCTAssertEqual(node.sourceTokens, tokens)
+        XCTAssertEqual(node.sourceTokens, tokens.dropLast())
 
         XCTAssertEqual(
             node,
@@ -45,7 +46,8 @@ final class WhileTest: XCTestCase {
                         .reserved(.parenthesisLeft),
                         .number("1"),
                         .reserved(.parenthesisRight),
-                        .reserved(.semicolon)
+                        .reserved(.semicolon),
+                        .endOfFile
                     ]
                 )
             ).stmt()

--- a/Tests/ParserTest/FunctionTest.swift
+++ b/Tests/ParserTest/FunctionTest.swift
@@ -16,7 +16,8 @@ final class FunctionTest: XCTestCase {
                 .reserved(.semicolon),
                 .number("2"),
                 .reserved(.semicolon),
-                .reserved(.braceRight)
+                .reserved(.braceRight),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).parse()
@@ -44,7 +45,8 @@ final class FunctionTest: XCTestCase {
                             )
                         )
                     )
-                ]
+                ],
+                endOfFile: TokenNode(token: tokens[10])
             )
         )
     }
@@ -62,7 +64,8 @@ final class FunctionTest: XCTestCase {
                 .reserved(.semicolon),
                 .number("2"),
                 .reserved(.semicolon),
-                .reserved(.braceRight)
+                .reserved(.braceRight),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).parse()
@@ -90,7 +93,8 @@ final class FunctionTest: XCTestCase {
                             )
                         )
                     )
-                ]
+                ],
+                endOfFile: TokenNode(token: tokens[11])
             )
         )
     }
@@ -137,7 +141,8 @@ final class FunctionTest: XCTestCase {
                 .reserved(.braceLeft),
                 .number("1"),
                 .reserved(.semicolon),
-                .reserved(.braceRight)
+                .reserved(.braceRight),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).parse()
@@ -167,7 +172,8 @@ final class FunctionTest: XCTestCase {
                             )
                         )
                     )
-                ]
+                ],
+                endOfFile: TokenNode(token: tokens[13])
             )
         )
     }
@@ -226,7 +232,8 @@ final class FunctionTest: XCTestCase {
                 .reserved(.braceLeft),
                 .number("1"),
                 .reserved(.semicolon),
-                .reserved(.braceRight)
+                .reserved(.braceRight),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).parse()
@@ -269,7 +276,8 @@ final class FunctionTest: XCTestCase {
                             )
                         )
                     )
-                ]
+                ],
+                endOfFile: TokenNode(token: tokens[16])
             )
         )
     }

--- a/Tests/ParserTest/OperatorPriorityTest.swift
+++ b/Tests/ParserTest/OperatorPriorityTest.swift
@@ -12,7 +12,7 @@ final class OperatorPriorityTest: XCTestCase {
                 .number("2"),
                 .reserved(.add),
                 .number("3"),
-                .reserved(.semicolon),
+                .reserved(.semicolon)
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
@@ -44,7 +44,7 @@ final class OperatorPriorityTest: XCTestCase {
                 .number("2"),
                 .reserved(.mul),
                 .number("3"),
-                .reserved(.semicolon),
+                .reserved(.semicolon)
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
@@ -76,7 +76,7 @@ final class OperatorPriorityTest: XCTestCase {
                 .number("2"),
                 .reserved(.mul),
                 .number("3"),
-                .reserved(.semicolon),
+                .reserved(.semicolon)
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
@@ -110,7 +110,7 @@ final class OperatorPriorityTest: XCTestCase {
                 .reserved(.parenthesisRight),
                 .reserved(.mul),
                 .number("3"),
-                .reserved(.semicolon),
+                .reserved(.semicolon)
             ]
         )
         let node = try Parser(tokens: tokens).stmt()

--- a/Tests/ParserTest/ParseErrorTest.swift
+++ b/Tests/ParserTest/ParseErrorTest.swift
@@ -12,6 +12,7 @@ final class ParseErrorTest: XCTestCase {
                         .number("1"),
                         .reserved(.add),
                         .reserved(.semicolon),
+                        .endOfFile
                     ]
                 )
             ).stmt()
@@ -28,6 +29,7 @@ final class ParseErrorTest: XCTestCase {
                         .reserved(.mul),
                         .number("1"),
                         .reserved(.semicolon),
+                        .endOfFile
                     ]
                 )
             ).stmt()
@@ -46,6 +48,7 @@ final class ParseErrorTest: XCTestCase {
                         .reserved(.mul),
                         .number("2"),
                         .reserved(.semicolon),
+                        .endOfFile
                     ]
                 )
             ).stmt()
@@ -70,6 +73,7 @@ final class ParseErrorTest: XCTestCase {
                         .number("1"),
                         .reserved(.add),
                         .number("2"),
+                        .endOfFile
                     ]
                 )
             ).stmt()

--- a/Tests/ParserTest/ReturnTest.swift
+++ b/Tests/ParserTest/ReturnTest.swift
@@ -10,11 +10,12 @@ final class ReturnTest: XCTestCase {
                 .keyword(.return),
                 .number("2"),
                 .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
 
-        XCTAssertEqual(node.sourceTokens, tokens)
+        XCTAssertEqual(node.sourceTokens, tokens.dropLast())
 
         XCTAssertEqual(
             node,
@@ -35,6 +36,7 @@ final class ReturnTest: XCTestCase {
                     kinds: [
                         .keyword(.return),
                         .reserved(.semicolon),
+                        .endOfFile
                     ]
                 )
             ).stmt()

--- a/Tests/ParserTest/StringLiteralTest.swift
+++ b/Tests/ParserTest/StringLiteralTest.swift
@@ -8,12 +8,13 @@ final class StringLiteralTest: XCTestCase {
         let tokens: [Token] = buildTokens(
             kinds: [
                 .stringLiteral("a"),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
 
-        XCTAssertEqual(node.sourceTokens, tokens)
+        XCTAssertEqual(node.sourceTokens, tokens.dropLast())
 
         XCTAssertEqual(
             node,
@@ -30,12 +31,13 @@ final class StringLiteralTest: XCTestCase {
                 .identifier("a"),
                 .reserved(.assign),
                 .stringLiteral("a"),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
 
-        XCTAssertEqual(node.sourceTokens, tokens)
+        XCTAssertEqual(node.sourceTokens, tokens.dropLast())
 
         XCTAssertEqual(
             node,

--- a/Tests/ParserTest/VariableTest.swift
+++ b/Tests/ParserTest/VariableTest.swift
@@ -9,12 +9,13 @@ final class VariableTest: XCTestCase {
             kinds: [
                 .type(.int),
                 .identifier("a"),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
 
-        XCTAssertEqual(node.sourceTokens, tokens)
+        XCTAssertEqual(node.sourceTokens, tokens.dropLast())
 
         XCTAssertEqual(
             node,
@@ -35,12 +36,13 @@ final class VariableTest: XCTestCase {
                 .identifier("a"),
                 .reserved(.assign),
                 .number("1"),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
 
-        XCTAssertEqual(node.sourceTokens, tokens)
+        XCTAssertEqual(node.sourceTokens, tokens.dropLast())
 
         XCTAssertEqual(
             node,
@@ -62,12 +64,13 @@ final class VariableTest: XCTestCase {
                 .type(.int),
                 .reserved(.mul),
                 .identifier("a"),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
 
-        XCTAssertEqual(node.sourceTokens, tokens)
+        XCTAssertEqual(node.sourceTokens, tokens.dropLast())
 
         XCTAssertEqual(
             node,
@@ -91,12 +94,13 @@ final class VariableTest: XCTestCase {
                 .reserved(.mul),
                 .reserved(.mul),
                 .identifier("a"),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
 
-        XCTAssertEqual(node.sourceTokens, tokens)
+        XCTAssertEqual(node.sourceTokens, tokens.dropLast())
 
         XCTAssertEqual(
             node,
@@ -125,7 +129,8 @@ final class VariableTest: XCTestCase {
                 .reserved(.squareLeft),
                 .number("4"),
                 .reserved(.squareRight),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
@@ -162,7 +167,8 @@ final class VariableTest: XCTestCase {
                 .reserved(.comma),
                 .number("2"),
                 .reserved(.braceRight),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
@@ -204,7 +210,8 @@ final class VariableTest: XCTestCase {
                 .reserved(.squareRight),
                 .reserved(.assign),
                 .stringLiteral("ai"),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
@@ -238,7 +245,8 @@ final class VariableTest: XCTestCase {
                 .reserved(.squareLeft),
                 .number("4"),
                 .reserved(.squareRight),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).stmt()
@@ -265,7 +273,8 @@ final class VariableTest: XCTestCase {
             kinds: [
                 .type(.int),
                 .identifier("a"),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).parse()
@@ -283,7 +292,8 @@ final class VariableTest: XCTestCase {
                         ),
                         semicolon: TokenNode(token: tokens[2])
                     )
-                ]
+                ], 
+                endOfFile: TokenNode(token: tokens[3])
             )
         )
     }
@@ -294,7 +304,8 @@ final class VariableTest: XCTestCase {
                 .type(.int),
                 .reserved(.mul),
                 .identifier("a"),
-                .reserved(.semicolon)
+                .reserved(.semicolon),
+                .endOfFile
             ]
         )
         let node = try Parser(tokens: tokens).parse()
@@ -315,7 +326,8 @@ final class VariableTest: XCTestCase {
                         ),
                         semicolon: TokenNode(token: tokens[3])
                     )
-                ]
+                ],
+                endOfFile: TokenNode(token: tokens[4])
             )
         )
     }

--- a/Tests/TokenizerTest/IdentifierTest.swift
+++ b/Tests/TokenizerTest/IdentifierTest.swift
@@ -14,6 +14,10 @@ final class IdentifierTest: XCTestCase {
                 Token(
                     kind: .identifier("a"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 2))
                 )
             ]
         )
@@ -38,6 +42,10 @@ final class IdentifierTest: XCTestCase {
                 Token(
                     kind: .identifier("b"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 4))
                 )
             ]
         )
@@ -54,6 +62,10 @@ final class IdentifierTest: XCTestCase {
                 Token(
                     kind: .identifier("ab"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 3))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 3))
                 )
             ]
         )
@@ -75,6 +87,10 @@ final class IdentifierTest: XCTestCase {
                 Token(
                     kind: .identifier("hoge"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 8))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 8), end: SourceLocation(line: 1, column: 8))
                 )
             ]
         )
@@ -91,6 +107,10 @@ final class IdentifierTest: XCTestCase {
                 Token(
                     kind: .identifier("AB"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 3))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 3))
                 )
             ]
         )
@@ -107,6 +127,10 @@ final class IdentifierTest: XCTestCase {
                 Token(
                     kind: .identifier("A2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 3))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 3))
                 )
             ]
         )
@@ -123,6 +147,10 @@ final class IdentifierTest: XCTestCase {
                 Token(
                     kind: .identifier("_"), 
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 2))
                 )
             ]
         )

--- a/Tests/TokenizerTest/KeywordsTest.swift
+++ b/Tests/TokenizerTest/KeywordsTest.swift
@@ -14,6 +14,10 @@ final class KeywordsTest: XCTestCase {
                 Token(
                     kind: .keyword(.return),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 7))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 7), end: SourceLocation(line: 1, column: 7))
                 )
             ]
         )
@@ -35,6 +39,10 @@ final class KeywordsTest: XCTestCase {
                 Token(
                     kind: .number("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 8), end: SourceLocation(line: 1, column: 9))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 9), end: SourceLocation(line: 1, column: 9))
                 )
             ]
         )
@@ -55,6 +63,10 @@ final class KeywordsTest: XCTestCase {
                 Token(
                     kind: .reserved(.semicolon),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 7), end: SourceLocation(line: 1, column: 8))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 8), end: SourceLocation(line: 1, column: 8))
                 )
             ]
         )
@@ -71,6 +83,10 @@ final class KeywordsTest: XCTestCase {
                 Token(
                     kind: .identifier("returnX"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 8))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 8), end: SourceLocation(line: 1, column: 8))
                 )
             ]
         )
@@ -87,6 +103,10 @@ final class KeywordsTest: XCTestCase {
                 Token(
                     kind: .identifier("return2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 8))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 8), end: SourceLocation(line: 1, column: 8))
                 )
             ]
         )
@@ -124,6 +144,10 @@ final class KeywordsTest: XCTestCase {
                 Token(
                     kind: .number("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 11), end: SourceLocation(line: 1, column: 12))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 12), end: SourceLocation(line: 1, column: 12))
                 )
             ]
         )
@@ -153,6 +177,10 @@ final class KeywordsTest: XCTestCase {
                     kind: .reserved(.parenthesisRight),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 8), end: SourceLocation(line: 1, column: 9))
                 ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 9), end: SourceLocation(line: 1, column: 9))
+                )
             ]
         )
     }
@@ -197,6 +225,10 @@ final class KeywordsTest: XCTestCase {
                     kind: .reserved(.parenthesisRight),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 10), end: SourceLocation(line: 1, column: 11))
                 ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 11), end: SourceLocation(line: 1, column: 11))
+                )
             ]
         )
     }
@@ -225,6 +257,10 @@ final class KeywordsTest: XCTestCase {
                     kind: .reserved(.parenthesisRight),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 9), end: SourceLocation(line: 1, column: 10))
                 ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 10), end: SourceLocation(line: 1, column: 10))
+                )
             ]
         )
     }

--- a/Tests/TokenizerTest/NumberTest.swift
+++ b/Tests/TokenizerTest/NumberTest.swift
@@ -14,6 +14,10 @@ final class NumberTest: XCTestCase {
                 Token(
                     kind: .number("5"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 2))
                 )
             ]
         )
@@ -30,6 +34,10 @@ final class NumberTest: XCTestCase {
                 Token(
                     kind: .number("123"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 4))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 4))
                 )
             ]
         )

--- a/Tests/TokenizerTest/StringLiteralTest.swift
+++ b/Tests/TokenizerTest/StringLiteralTest.swift
@@ -14,6 +14,10 @@ final class StringLiteralTest: XCTestCase {
                 Token(
                     kind: .stringLiteral("aaaa"),
                     sourceRange: SourceRange(start: .init(line: 1, column: 1), end: .init(line: 1, column: 7))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 7), end: SourceLocation(line: 1, column: 7))
                 )
             ]
         )

--- a/Tests/TokenizerTest/TokensTest.swift
+++ b/Tests/TokenizerTest/TokensTest.swift
@@ -21,6 +21,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .number("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 4))
                 )
             ]
         )
@@ -45,6 +49,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .number("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 4))
                 )
             ]
         )
@@ -69,6 +77,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .number("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 4))
                 )
             ]
         )
@@ -93,6 +105,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .number("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 4))
                 )
             ]
         )
@@ -113,6 +129,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .identifier("a"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 3))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 3))
                 )
             ]
         )
@@ -137,6 +157,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .reserved(.parenthesisRight),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 4))
                 )
             ]
         )
@@ -161,6 +185,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .reserved(.squareRight),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 4))
                 )
             ]
         )
@@ -189,6 +217,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .reserved(.braceRight),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 5))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 5), end: SourceLocation(line: 1, column: 5))
                 )
             ]
         )
@@ -213,6 +245,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .number("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 5))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 5), end: SourceLocation(line: 1, column: 5))
                 )
             ]
         )
@@ -237,6 +273,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .number("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 5))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 5), end: SourceLocation(line: 1, column: 5))
                 )
             ]
         )
@@ -261,6 +301,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .number("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 4))
                 )
             ]
         )
@@ -285,6 +329,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .number("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 5))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 5), end: SourceLocation(line: 1, column: 5))
                 )
             ]
         )
@@ -309,6 +357,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .number("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 4))
                 )
             ]
         )
@@ -333,6 +385,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .number("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 5))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 5), end: SourceLocation(line: 1, column: 5))
                 )
             ]
         )
@@ -358,6 +414,10 @@ final class TokensTest: XCTestCase {
                     kind: .number("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 4))
+                )
             ]
         )
     }
@@ -378,6 +438,10 @@ final class TokensTest: XCTestCase {
                     kind: .reserved(.semicolon),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 3))
                 ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 3))
+                )
             ]
         )
     }
@@ -401,6 +465,10 @@ final class TokensTest: XCTestCase {
                 Token(
                     kind: .number("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 4))
                 )
             ]
         )

--- a/Tests/TokenizerTest/TypesTest.swift
+++ b/Tests/TokenizerTest/TypesTest.swift
@@ -19,6 +19,10 @@ final class TypesTest: XCTestCase {
                 Token(
                     kind: .identifier("a"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 5), end: SourceLocation(line: 1, column: 6))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 6), end: SourceLocation(line: 1, column: 6))
                 )
             ]
         )
@@ -35,6 +39,10 @@ final class TypesTest: XCTestCase {
                 Token(
                     kind: .identifier("inta"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 5))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 5), end: SourceLocation(line: 1, column: 5))
                 )
             ]
         )
@@ -56,6 +64,10 @@ final class TypesTest: XCTestCase {
                 Token(
                     kind: .identifier("a"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 6), end: SourceLocation(line: 1, column: 7))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 7), end: SourceLocation(line: 1, column: 7))
                 )
             ]
         )
@@ -72,6 +84,10 @@ final class TypesTest: XCTestCase {
                 Token(
                     kind: .identifier("chara"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 6))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 6), end: SourceLocation(line: 1, column: 6))
                 )
             ]
         )

--- a/Tests/TokenizerTest/WhiteSpaceTest.swift
+++ b/Tests/TokenizerTest/WhiteSpaceTest.swift
@@ -24,6 +24,10 @@ final class WhiteSpaceTest: XCTestCase {
                 Token(
                     kind: .number("23"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 7), end: SourceLocation(line: 1, column: 9))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 9), end: SourceLocation(line: 1, column: 9))
                 )
             ]
         )
@@ -50,6 +54,10 @@ final class WhiteSpaceTest: XCTestCase {
                 Token(
                     kind: .number("23"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 6), end: SourceLocation(line: 1, column: 8))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 8), end: SourceLocation(line: 1, column: 8))
                 )
             ]
         )
@@ -76,6 +84,10 @@ final class WhiteSpaceTest: XCTestCase {
                     kind: .number("23"),
                     leadingTrivia: "\n",
                     sourceRange: SourceRange(start: SourceLocation(line: 2, column: 1), end: SourceLocation(line: 2, column: 3))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 2, column: 3), end: SourceLocation(line: 2, column: 3))
                 )
             ]
         )
@@ -103,6 +115,10 @@ final class WhiteSpaceTest: XCTestCase {
                     kind: .number("23"),
                     leadingTrivia: "\n ",
                     sourceRange: SourceRange(start: SourceLocation(line: 2, column: 2), end: SourceLocation(line: 2, column: 4))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 2, column: 4), end: SourceLocation(line: 2, column: 4))
                 )
             ]
         )
@@ -129,6 +145,44 @@ final class WhiteSpaceTest: XCTestCase {
                 Token(
                     kind: .number("23"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 15), end: SourceLocation(line: 1, column: 17))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 17), end: SourceLocation(line: 1, column: 17))
+                )
+            ]
+        )
+    }
+
+    func testEndWithTrivia() throws {
+        let source = """
+a = 1
+// a
+"""
+        let tokens = try Tokenizer(source: source).tokenize()
+
+        XCTAssertEqual(tokens.reduce("") { $0 + $1.description }, source)
+        XCTAssertEqual(
+            tokens,
+            [
+                Token(
+                    kind: .identifier("a"),
+                    trailingTrivia: " ",
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
+                ),
+                Token(
+                    kind: .reserved(.assign),
+                    trailingTrivia: " ",
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
+                ),
+                Token(
+                    kind: .number("1"),
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 5), end: SourceLocation(line: 1, column: 6))
+                ),
+                Token(
+                    kind: .endOfFile,
+                    leadingTrivia: "\n// a",
+                    sourceRange: SourceRange(start: SourceLocation(line: 2, column: 5), end: SourceLocation(line: 2, column: 5))
                 )
             ]
         )


### PR DESCRIPTION
# 概要
- EOF Tokenを導入する
    - コメントなどのtriviaで終わっている場合、EOF Tokenのleading triviaにして吸収するため

# 実装
- `TokenKind`に`endOfFile`を追加
- ParserでのTokenの範囲外アクセスのチェックが不要になり、綺麗になった

# 備考
- `stmt()`の単体テストにて、EOF Tokenがないと動作しないが、パース結果にはEOF Tokenは含まれないのでtokenのAssertで困った
    - （問題にはなってないが）そもそも実際に存在しない入力でテストするのは良くないのでは？
    - とりあえず`tokens.dropLast()`でたいしょ