### PR TITLE
ParserでのTokenの利用方法をリファクタする

### DIFF
--- a/Sources/Parser/Parser+ConsumeToken.swift
+++ b/Sources/Parser/Parser+ConsumeToken.swift
@@ -5,8 +5,26 @@ extension Parser {
         return spec ~= tokens[index]
     }
 
+    func at(_ specs: TokenSpec...) -> Bool {
+        for spec in specs where at(spec) {
+            return true
+        }
+
+        return false
+    }
+
     func consume(if spec: TokenSpec) -> TokenNode? {
         return try? consume(spec)
+    }
+
+    func consume(if specs: TokenSpec...) -> TokenNode? {
+        for spec in specs {
+            if let token = consume(if: spec) {
+                return token
+            }
+        }
+
+        return nil
     }
 
     /// `eat` in SwiftSyntax
@@ -18,5 +36,15 @@ extension Parser {
         } else {
             throw ParseError.invalidSyntax(location: tokens[index].sourceRange.start)
         }
+    }
+
+    func consume(_ specs: TokenSpec...) throws -> TokenNode {
+        for spec in specs where at(spec) {
+            let token = tokens[index]
+            index += 1
+            return TokenNode(token: token)
+        }
+
+        throw ParseError.invalidSyntax(location: tokens[index].sourceRange.start)
     }
 }

--- a/Sources/Parser/Parser+ConsumeToken.swift
+++ b/Sources/Parser/Parser+ConsumeToken.swift
@@ -1,0 +1,22 @@
+import Tokenizer
+
+extension Parser {
+    func at(_ spec: TokenSpec) -> Bool {
+        return spec ~= tokens[index]
+    }
+
+    func consume(if spec: TokenSpec) -> TokenNode? {
+        return try? consume(spec)
+    }
+
+    /// `eat` in SwiftSyntax
+    func consume(_ spec: TokenSpec) throws -> TokenNode {
+        if at(spec) {
+            let token = tokens[index]
+            index += 1
+            return TokenNode(token: token)
+        } else {
+            throw ParseError.invalidSyntax(location: tokens[index].sourceRange.start)
+        }
+    }
+}

--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -407,17 +407,11 @@ public final class Parser {
                 parenthesisRight: try consume(.reserved(.parenthesisRight))
             )
 
-        case .number:
-            let numberToken = try consume(.integerLiteral)
-            let numberNode = IntegerLiteralNode(literal: numberToken)
-
-            return numberNode
+        case .integerLiteral:
+            return IntegerLiteralNode(literal: try consume(.integerLiteral))
 
         case .stringLiteral:
-            let stringToken = try consume(.stringLiteral)
-            let stringLiteralNode = StringLiteralNode(literal: stringToken)
-
-            return stringLiteralNode
+            return StringLiteralNode(literal: try consume(.stringLiteral))
 
         case .identifier:
             let identifierToken = try consume(.identifier)

--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -18,11 +18,7 @@ public final class Parser {
     // MARK: - Public
 
     public func parse() throws -> SourceFileNode {
-        if tokens.isEmpty {
-            throw ParseError.invalidSyntax(location: .startOfFile)
-        }
-
-        return try program()
+        try program()
     }
 
     // MARK: - Syntax
@@ -37,11 +33,9 @@ public final class Parser {
             let identifier = try consume(.identifier)
 
             // functionDecl = type ident "(" functionParameters? ")" block
-            if case .reserved(.parenthesisLeft) = tokens[index].kind {
-                let parenthesisLeft = try consume(.reserved(.parenthesisLeft))
-
+            if let parenthesisLeft = consume(if: .reserved(.parenthesisLeft)) {
                 var parameters: [FunctionParameterNode] = []
-                if case .type = tokens[index].kind {
+                if at(.type) {
                     parameters = try functionParameters()
                 }
 
@@ -70,15 +64,9 @@ public final class Parser {
     func functionParameters() throws -> [FunctionParameterNode] {
         var results: [FunctionParameterNode] = []
 
-        results.append(try functionParameter())
-
-        while tokens[index].kind != .endOfFile {
-            if case .reserved(.parenthesisRight) = tokens[index].kind {
-                break
-            }
-
+        repeat {
             results.append(try functionParameter())
-        }
+        } while !at(.reserved(.parenthesisRight))
 
         return results
     }
@@ -88,7 +76,7 @@ public final class Parser {
         var type = try type()
         let identifier = try consume(.identifier)
 
-        if case .reserved(.squareLeft) = tokens[index].kind {
+        if at(.reserved(.squareLeft)) {
             type = ArrayTypeNode(
                 elementType: type,
                 squareLeft: try consume(.reserved(.squareLeft)),
@@ -97,18 +85,11 @@ public final class Parser {
             )
         }
 
-        if case .reserved(.comma) = tokens[index].kind {
-            return FunctionParameterNode(
-                type: type,
-                identifier: identifier,
-                comma: try consume(.reserved(.comma))
-            )
-        } else {
-            return FunctionParameterNode(
-                type: type,
-                identifier: identifier
-            )
-        }
+        return FunctionParameterNode(
+            type: type,
+            identifier: identifier,
+            comma: consume(if: .reserved(.comma))
+        )
     }
 
     // stmt    = expr ";"
@@ -137,7 +118,7 @@ public final class Parser {
 
             var elseToken: TokenNode?
             var falseStatement: BlockItemNode?
-            if case .keyword(.else) = tokens[index].kind {
+            if at(.keyword(.else)) {
                 elseToken = try consume(.keyword(.else))
                 falseStatement = try stmt()
             }
@@ -175,8 +156,8 @@ public final class Parser {
 
             var preExpr: (any NodeProtocol)?
             let firstSemicolon: TokenNode
-            if case .reserved(.semicolon) = tokens[index].kind {
-                firstSemicolon = try consume(.reserved(.semicolon))
+            if let semicolon = consume(if: .reserved(.semicolon)) {
+                firstSemicolon = semicolon
             } else {
                 preExpr = try expr()
                 firstSemicolon = try consume(.reserved(.semicolon))
@@ -184,8 +165,8 @@ public final class Parser {
 
             var condition: (any NodeProtocol)?
             let secondSemicolon: TokenNode
-            if case .reserved(.semicolon) = tokens[index].kind {
-                secondSemicolon = try consume(.reserved(.semicolon))
+            if let semicolon = consume(if: .reserved(.semicolon)) {
+                secondSemicolon = semicolon
             } else {
                 condition = try expr()
                 secondSemicolon = try consume(.reserved(.semicolon))
@@ -193,8 +174,8 @@ public final class Parser {
 
             var postExpr: (any NodeProtocol)?
             let parenthesisRight: TokenNode
-            if case .reserved(.parenthesisRight) = tokens[index].kind {
-                parenthesisRight = try consume(.reserved(.parenthesisRight))
+            if let paren = consume(if: .reserved(.parenthesisRight)) {
+                parenthesisRight = paren
             } else {
                 postExpr = try expr()
                 parenthesisRight = try consume(.reserved(.parenthesisRight))
@@ -236,11 +217,7 @@ public final class Parser {
         let braceLeft = try consume(.reserved(.braceLeft))
 
         var items: [BlockItemNode] = []
-        while tokens[index].kind != .endOfFile {
-            if case .reserved(.braceRight) = tokens[index].kind {
-                break
-            }
-
+        while !at(.reserved(.braceRight)) {
             items.append(try stmt())
         }
 
@@ -258,7 +235,7 @@ public final class Parser {
         var type = if let variableType { variableType } else { try type() }
         let identifier = if let identifier { identifier } else { try consume(.identifier) }
 
-        if case .reserved(.squareLeft) = tokens[index].kind {
+        if at(.reserved(.squareLeft)) {
             type = ArrayTypeNode(
                 elementType: type,
                 squareLeft: try consume(.reserved(.squareLeft)),
@@ -267,9 +244,7 @@ public final class Parser {
             )
         }
 
-        if case .reserved(.assign) = tokens[index].kind {
-            let initializer = try consume(.reserved(.assign))
-
+        if let initializer = consume(if: .reserved(.assign)) {
             switch tokens[index].kind {
             case .reserved(.braceLeft):
                 return VariableDeclNode(
@@ -311,13 +286,8 @@ public final class Parser {
     func type() throws -> any TypeNodeProtocol {
         var node: any TypeNodeProtocol = TypeNode(type: try consume(.type))
 
-        while tokens[index].kind != .endOfFile {
-            if case .reserved(.mul) = tokens[index].kind {
-                let mulToken = try consume(.reserved(.mul))
-                node = PointerTypeNode(referenceType: node, pointer: mulToken)
-            } else {
-                break
-            }
+        while let mulToken = consume(if: .reserved(.mul)) {
+            node = PointerTypeNode(referenceType: node, pointer: mulToken)
         }
 
         return node
@@ -332,8 +302,7 @@ public final class Parser {
     func assign() throws -> any NodeProtocol {
         var node = try equality()
 
-        if case .reserved(.assign) = tokens[index].kind {
-            let token = try consume(.reserved(.assign))
+        if let token = consume(if: .reserved(.assign)) {
             let rightNode = try assign()
 
             node = InfixOperatorExpressionNode(
@@ -346,204 +315,81 @@ public final class Parser {
         return node
     }
 
-    // equality = relational ("==" relational | "!=" relational)*
+    // equality = relational (("==" | "!=") relational)*
     func equality() throws -> any NodeProtocol {
         var node = try relational()
 
-        while tokens[index].kind != .endOfFile {
-            switch tokens[index].kind {
-            case .reserved(.equal):
-                let token = try consume(.reserved(.equal))
-                let rightNode = try relational()
-
-                node = InfixOperatorExpressionNode(
-                    left: node, 
-                    operator: BinaryOperatorNode(operator: token),
-                    right: rightNode
-                )
-
-            case .reserved(.notEqual):
-                let token = try consume(.reserved(.notEqual))
-                let rightNode = try relational()
-
-                node = InfixOperatorExpressionNode(
-                    left: node, 
-                    operator: BinaryOperatorNode(operator: token),
-                    right: rightNode
-                )
-
-            default:
-                return node
-            }
+        while let equalityToken = consume(if: .reserved(.equal), .reserved(.notEqual)) {
+            node = InfixOperatorExpressionNode(
+                left: node,
+                operator: BinaryOperatorNode(operator: equalityToken),
+                right: try relational()
+            )
         }
 
         return node
     }
 
-    // relational = add ("<" add | "<=" add | ">" add | ">=" add)*
+    // relational = add (("<" | "<=" | ">" | ">=") add)*
     func relational() throws -> any NodeProtocol {
         var node = try add()
 
-        while tokens[index].kind != .endOfFile {
-            switch tokens[index].kind {
-            case .reserved(.lessThan):
-                let token = try consume(.reserved(.lessThan))
-                let rightNode = try add()
-
-                node = InfixOperatorExpressionNode(
-                    left: node, 
-                    operator: BinaryOperatorNode(operator: token),
-                    right: rightNode
-                )
-
-            case .reserved(.lessThanOrEqual):
-                let token = try consume(.reserved(.lessThanOrEqual))
-                let rightNode = try add()
-
-                node = InfixOperatorExpressionNode(
-                    left: node, 
-                    operator: BinaryOperatorNode(operator: token),
-                    right: rightNode
-                )
-
-            case .reserved(.greaterThan):
-                let token = try consume(.reserved(.greaterThan))
-                let rightNode = try add()
-
-                node = InfixOperatorExpressionNode(
-                    left: node, 
-                    operator: BinaryOperatorNode(operator: token),
-                    right: rightNode
-                )
-
-            case .reserved(.greaterThanOrEqual):
-                let token = try consume(.reserved(.greaterThanOrEqual))
-                let rightNode = try add()
-
-                node = InfixOperatorExpressionNode(
-                    left: node, 
-                    operator: BinaryOperatorNode(operator: token),
-                    right: rightNode
-                )
-
-            default:
-                return node
-            }
+        while let relationalToken = consume(if: .reserved(.lessThan), .reserved(.lessThanOrEqual), .reserved(.greaterThan), .reserved(.greaterThanOrEqual)) {
+            node = InfixOperatorExpressionNode(
+                left: node,
+                operator: BinaryOperatorNode(operator: relationalToken),
+                right: try add()
+            )
         }
 
         return node
     }
 
-    // add = mul ("+" mul | "-" mul)*
+    // add = mul (("+" | "-") mul)*
     func add() throws -> any NodeProtocol {
         var node = try mul()
 
-        while tokens[index].kind != .endOfFile {
-            switch tokens[index].kind {
-            case .reserved(.add):
-                let addToken = try consume(.reserved(.add))
-                let rightNode = try mul()
-
-                node = InfixOperatorExpressionNode(
-                    left: node, 
-                    operator: BinaryOperatorNode(operator: addToken),
-                    right: rightNode
-                )
-
-            case .reserved(.sub):
-                let subToken = try consume(.reserved(.sub))
-                let rightNode = try mul()
-
-                node = InfixOperatorExpressionNode(
-                    left: node, 
-                    operator: BinaryOperatorNode(operator: subToken),
-                    right: rightNode
-                )
-
-            default:
-                return node
-            }
+        while let addOrSub = consume(if: .reserved(.add), .reserved(.sub)) {
+            node = InfixOperatorExpressionNode(
+                left: node,
+                operator: BinaryOperatorNode(operator: addOrSub),
+                right: try mul()
+            )
         }
 
         return node
     }
 
-    // mul = unary ("*" unary | "/" unary)*
+    // mul = unary (("*" |"/") unary)*
     func mul() throws -> any NodeProtocol {
         var node = try unary()
 
-        while tokens[index].kind != .endOfFile {
-            switch tokens[index].kind {
-            case .reserved(.mul):
-                let mulToken = try consume(.reserved(.mul))
-                let rightNode = try unary()
-
-                node = InfixOperatorExpressionNode(
-                    left: node, 
-                    operator: BinaryOperatorNode(operator: mulToken),
-                    right: rightNode
-                )
-
-            case .reserved(.div):
-                let divToken = try consume(.reserved(.div))
-                let rightNode = try unary()
-
-                node = InfixOperatorExpressionNode(
-                    left: node, 
-                    operator: BinaryOperatorNode(operator: divToken),
-                    right: rightNode
-                )
-
-            default:
-                return node
-            }
+        while let mulOrDivToken = consume(if: .reserved(.mul), .reserved(.div)) {
+            node = InfixOperatorExpressionNode(
+                left: node,
+                operator: BinaryOperatorNode(operator: mulOrDivToken),
+                right: try unary()
+            )
         }
 
         return node
     }
 
-    // unary = "sizeof" unary
-    //       | ("+" | "-")? primary
-    //       | ("*" | "&") unary
+    // unary = | ("+" | "-") primary
+    //         | ("sizeof" | "*" | "&") unary
+    //         | primary
     func unary() throws -> any NodeProtocol {
-        switch tokens[index].kind {
-        case .keyword(.sizeof):
+        if let addOrSub = consume(if: .reserved(.add), .reserved(.sub)) {
             return PrefixOperatorExpressionNode(
-                operator: try consume(.keyword(.sizeof)),
+                operator: addOrSub,
+                expression: try primary()
+            )
+        } else if let sizeofOrMulOrAnd = consume(if: .keyword(.sizeof), .reserved(.mul), .reserved(.and)) {
+            return PrefixOperatorExpressionNode(
+                operator: sizeofOrMulOrAnd,
                 expression: try unary()
             )
-
-        case .reserved(.add):
-            return PrefixOperatorExpressionNode(
-                operator: try consume(.reserved(.add)),
-                expression: try primary()
-            )
-
-        case .reserved(.sub):
-            return PrefixOperatorExpressionNode(
-                operator: try consume(.reserved(.sub)),
-                expression: try primary()
-            )
-
-        case .reserved(.mul):
-            let mulToken = try consume(.reserved(.mul))
-            let right = try unary()
-
-            return PrefixOperatorExpressionNode(
-                operator: mulToken,
-                expression: right
-            )
-
-        case .reserved(.and):
-            let andToken = try consume(.reserved(.and))
-            let right = try unary()
-
-            return PrefixOperatorExpressionNode(
-                operator: andToken,
-                expression: right
-            )
-
-        default:
+        } else {
             return try primary()
         }
     }
@@ -576,16 +422,10 @@ public final class Parser {
         case .identifier:
             let identifierToken = try consume(.identifier)
 
-            if case .reserved(.parenthesisLeft) = tokens[index].kind {
-                let parenthesisLeft = try consume(.reserved(.parenthesisLeft))
-
+            if let parenthesisLeft = consume(if: .reserved(.parenthesisLeft)) {
                 var argments: [ExpressionListItemNode] = []
-                if tokens[index].kind != .endOfFile {
-                    if case .reserved(.parenthesisRight) = tokens[index].kind {
-
-                    } else {
-                        argments = try exprList()
-                    }
+                if !at(.reserved(.parenthesisRight)) {
+                    argments = try exprList()
                 }
 
                 let parenthesisRight = try consume(.reserved(.parenthesisRight))
@@ -596,7 +436,7 @@ public final class Parser {
                     arguments: argments,
                     parenthesisRight: parenthesisRight
                 )
-            } else if case .reserved(.squareLeft) = tokens[index].kind {
+            } else if at(.reserved(.squareLeft)) {
                 return SubscriptCallExpressionNode(
                     identifier: IdentifierNode(baseName: identifierToken),
                     squareLeft: try consume(.reserved(.squareLeft)),
@@ -612,33 +452,19 @@ public final class Parser {
         }
     }
 
-    // exprList = exprList+
+    // exprList = (expr ","?)+
     func exprList() throws -> [ExpressionListItemNode] {
         var results: [ExpressionListItemNode] = []
-        results.append(try exprListItem())
 
-        while tokens[index].kind != .endOfFile {
-            if case .reserved = tokens[index].kind {
-                // ), }だったら
-                break
-            } else {
-                results.append(try exprListItem())
-            }
-        }
+        repeat {
+            results.append(
+                ExpressionListItemNode(
+                    expression: try expr(),
+                    comma: consume(if: .reserved(.comma))
+                )
+            )
+        } while !(at(.reserved(.parenthesisRight)) || at(.reserved(.braceRight)))
 
         return results
-    }
-
-    // exprListItem = expr ","?
-    func exprListItem() throws -> ExpressionListItemNode {
-        let expr = try expr()
-        if case .reserved(.comma) = tokens[index].kind {
-            return ExpressionListItemNode(
-                expression: expr,
-                comma: try consume(.reserved(.comma))
-            )
-        } else {
-            return ExpressionListItemNode(expression: expr)
-        }
     }
 }

--- a/Sources/Tokenizer/Token.swift
+++ b/Sources/Tokenizer/Token.swift
@@ -14,7 +14,7 @@ public struct Token: Equatable {
 
     /// with trivia
     public var description: String {
-        leadingTrivia + kind.text + trailingTrivia
+        leadingTrivia + text + trailingTrivia
     }
 
     // MARK: - Initializer
@@ -61,9 +61,70 @@ extension SourceLocation {
     public static let startOfFile = SourceLocation(line: 1, column: 1)
 }
 
-public enum TokenKind: Equatable {
+/// TokenKindはAssociatedValuesがあって比較に不便なため
+/// AssociatedValuesを抜いたもの
+public enum TokenSpec: Equatable {
 
-    // MARK: - Property
+    case reserved(_ kind: ReservedKind)
+    case keyword(_ kind: KeywordKind)
+    case integerLiteral
+    case stringLiteral
+    case identifier
+    case type
+
+    case endOfFile
+
+    public static func ~= (spec: TokenSpec, token: Token) -> Bool {
+        switch spec {
+        case .reserved(let kind):
+            if case .reserved(let tokenKind) = token.kind {
+                return kind == tokenKind
+            } else {
+                return false
+            }
+
+        case .keyword(let kind):
+            if case .keyword(let tokenKind) = token.kind {
+                return kind == tokenKind
+            } else {
+                return false
+            }
+
+        case .integerLiteral:
+            if case .number = token.kind {
+                return true
+            } else {
+                return false
+            }
+
+        case .stringLiteral:
+            if case .stringLiteral = token.kind {
+                return true
+            } else {
+                return false
+            }
+
+        case .identifier:
+            if case .identifier = token.kind {
+                return true
+            } else {
+                return false
+            }
+
+        case .type:
+            if case .type = token.kind {
+                return true
+            } else {
+                return false
+            }
+
+        case .endOfFile:
+            return token.kind == .endOfFile
+        }
+    }
+}
+
+public enum TokenKind: Equatable {
 
     case reserved(_ kind: ReservedKind)
     case keyword(_ kind: KeywordKind)
@@ -73,6 +134,8 @@ public enum TokenKind: Equatable {
     case type(_ kind: TypeKind)
 
     case endOfFile
+
+    // MARK: - Property
 
     public var text: String {
         switch self {
@@ -98,81 +161,81 @@ public enum TokenKind: Equatable {
             return ""
         }
     }
+}
 
-    public enum ReservedKind: String, CaseIterable {
-        /// `+`
-        case add = "+"
+public enum ReservedKind: String, CaseIterable {
+    /// `+`
+    case add = "+"
 
-        /// `-`
-        case sub = "-"
+    /// `-`
+    case sub = "-"
 
-        /// `*`
-        case mul = "*"
+    /// `*`
+    case mul = "*"
 
-        /// `/`
-        case div = "/"
+    /// `/`
+    case div = "/"
 
-        /// `&`
-        case and = "&"
+    /// `&`
+    case and = "&"
 
-        /// `(`
-        case parenthesisLeft = "("
+    /// `(`
+    case parenthesisLeft = "("
 
-        /// `)`
-        case parenthesisRight = ")"
+    /// `)`
+    case parenthesisRight = ")"
 
-        /// `{`
-        case braceLeft = "{"
+    /// `{`
+    case braceLeft = "{"
 
-        /// `}`
-        case braceRight = "}"
+    /// `}`
+    case braceRight = "}"
 
-        /// `[`
-        case squareLeft = "["
+    /// `[`
+    case squareLeft = "["
 
-        /// `]`
-        case squareRight = "]"
+    /// `]`
+    case squareRight = "]"
 
-        /// `==`
-        case equal = "=="
+    /// `==`
+    case equal = "=="
 
-        /// `!=`
-        case notEqual = "!="
+    /// `!=`
+    case notEqual = "!="
 
-        /// `<`
-        case lessThan = "<"
+    /// `<`
+    case lessThan = "<"
 
-        /// `<=`
-        case lessThanOrEqual = "<="
+    /// `<=`
+    case lessThanOrEqual = "<="
 
-        /// `>`
-        case greaterThan = ">"
+    /// `>`
+    case greaterThan = ">"
 
-        /// `>=`
-        case greaterThanOrEqual = ">="
+    /// `>=`
+    case greaterThanOrEqual = ">="
 
-        /// `=`
-        case assign = "="
+    /// `=`
+    case assign = "="
 
-        /// `;`
-        case semicolon = ";"
+    /// `;`
+    case semicolon = ";"
 
-        /// `,`
-        case comma = ","
-    }
+    /// `,`
+    case comma = ","
+}
 
-    public enum KeywordKind: String, CaseIterable {
-        case `return`
-        case `if`
-        case `else`
-        case `while`
-        case `for`
+public enum KeywordKind: String, CaseIterable {
+    case `return`
+    case `if`
+    case `else`
+    case `while`
+    case `for`
 
-        case sizeof
-    }
+    case sizeof
+}
 
-    public enum TypeKind: String, CaseIterable {
-        case int
-        case char
-    }
+public enum TypeKind: String, CaseIterable {
+    case int
+    case char
 }

--- a/Sources/Tokenizer/Token.swift
+++ b/Sources/Tokenizer/Token.swift
@@ -91,7 +91,7 @@ public enum TokenSpec: Equatable {
             }
 
         case .integerLiteral:
-            if case .number = token.kind {
+            if case .integerLiteral = token.kind {
                 return true
             } else {
                 return false
@@ -128,7 +128,7 @@ public enum TokenKind: Equatable {
 
     case reserved(_ kind: ReservedKind)
     case keyword(_ kind: KeywordKind)
-    case number(_ value: String)
+    case integerLiteral(_ value: String)
     case stringLiteral(_ value: String)
     case identifier(_ value: String)
     case type(_ kind: TypeKind)
@@ -145,7 +145,7 @@ public enum TokenKind: Equatable {
         case .keyword(let kind):
             return kind.rawValue
 
-        case .number(let value):
+        case .integerLiteral(let value):
             return value
 
         case .stringLiteral(let value):

--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -55,7 +55,7 @@ public class Tokenizer {
 
     // MARK: - Private
 
-    private func extractNumber() -> TokenKind {
+    private func extractIntegerLiteral() -> TokenKind {
         var string = ""
 
         while index < charactors.count {
@@ -68,10 +68,10 @@ public class Tokenizer {
             }
         }
 
-        return .number(string)
+        return .integerLiteral(string)
     }
 
-    private func extractString() -> TokenKind {
+    private func extractStringLiteral() -> TokenKind {
         var content = ""
 
         // 開始の"
@@ -176,11 +176,11 @@ public class Tokenizer {
         }
 
         if charactors[index].isNumber {
-            return extractNumber()
+            return extractIntegerLiteral()
         }
 
         if charactors[index] == "\"" {
-            return extractString()
+            return extractStringLiteral()
         }
 
         for reservedKind in reservedKinds {

--- a/Sources/Tokenizer/Tokenizer.swift
+++ b/Sources/Tokenizer/Tokenizer.swift
@@ -31,7 +31,7 @@ public class Tokenizer {
     public func tokenize() throws -> [Token] {
         var tokens: [Token] = []
 
-        while index < charactors.count {
+        while tokens.last?.kind != .endOfFile {
             let leadingTrivia = extractTrivia(untilBeforeNewLine: false)
 
             // sourceLocationにtriviaは含まない
@@ -48,10 +48,6 @@ public class Tokenizer {
                 sourceRange: SourceRange(start: startLocation, end: endLocation)
             )
             tokens.append(token)
-        }
-
-        if let lastToken = tokens.last, lastToken.kind != .endOfFile {
-            tokens.append(Token(kind: .endOfFile, sourceRange: SourceRange(start: currentSourceLocation, end: currentSourceLocation)))
         }
 
         return tokens
@@ -170,9 +166,9 @@ public class Tokenizer {
 
     // 文字数が多い物からチェックしないといけない
     // 例: <= の時に<を先にチェックすると<, =の2つのトークンになってしまう
-    private let reservedKinds = TokenKind.ReservedKind.allCases.sorted { $0.rawValue.count > $1.rawValue.count }
-    private let keywordKinds = TokenKind.KeywordKind.allCases.sorted { $0.rawValue.count > $1.rawValue.count }
-    private let typeKinds = TokenKind.TypeKind.allCases.sorted { $0.rawValue.count > $1.rawValue.count }
+    private let reservedKinds = ReservedKind.allCases.sorted { $0.rawValue.count > $1.rawValue.count }
+    private let keywordKinds = KeywordKind.allCases.sorted { $0.rawValue.count > $1.rawValue.count }
+    private let typeKinds = TypeKind.allCases.sorted { $0.rawValue.count > $1.rawValue.count }
 
     private func extractTokenKind() throws -> TokenKind {
         if index >= charactors.count {

--- a/Tests/ParserTest/AssignTest.swift
+++ b/Tests/ParserTest/AssignTest.swift
@@ -9,7 +9,7 @@ final class AssignTest: XCTestCase {
             kinds: [
                 .identifier("a"),
                 .reserved(.assign),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon)
             ]
         )
@@ -37,7 +37,7 @@ final class AssignTest: XCTestCase {
                 .reserved(.assign),
                 .identifier("b"),
                 .reserved(.assign),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon)
             ]
         )
@@ -66,9 +66,9 @@ final class AssignTest: XCTestCase {
     func testAssingToNumber() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.assign),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon)
             ]
         )

--- a/Tests/ParserTest/BuildTokenTest.swift
+++ b/Tests/ParserTest/BuildTokenTest.swift
@@ -26,7 +26,7 @@ final class BuildTokenTest: XCTestCase {
         let kinds: [TokenKind] = [
             .identifier("a"),
             .reserved(.assign),
-            .number("2"),
+            .integerLiteral("2"),
             .reserved(.semicolon)
         ]
         let tokens = buildTokens(kinds: kinds)
@@ -73,9 +73,9 @@ final class BuildTokenTest: XCTestCase {
             .reserved(.parenthesisLeft),
             .reserved(.parenthesisRight),
             .reserved(.braceLeft),
-            .number("1"),
+            .integerLiteral("1"),
             .reserved(.semicolon),
-            .number("2"),
+            .integerLiteral("2"),
             .reserved(.semicolon),
             .reserved(.braceRight)
         ]

--- a/Tests/ParserTest/Control/ForTest.swift
+++ b/Tests/ParserTest/Control/ForTest.swift
@@ -9,13 +9,13 @@ final class ForTest: XCTestCase {
             kinds: [
                 .keyword(.for),
                 .reserved(.parenthesisLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.semicolon),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon),
-                .number("3"),
+                .integerLiteral("3"),
                 .reserved(.parenthesisRight),
-                .number("4"),
+                .integerLiteral("4"),
                 .reserved(.semicolon)
             ]
         )
@@ -49,16 +49,16 @@ final class ForTest: XCTestCase {
             kinds: [
                 .keyword(.for),
                 .reserved(.parenthesisLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.semicolon),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon),
-                .number("3"),
+                .integerLiteral("3"),
                 .reserved(.parenthesisRight),
                 .reserved(.braceLeft),
-                .number("4"),
+                .integerLiteral("4"),
                 .reserved(.semicolon),
-                .number("5"),
+                .integerLiteral("5"),
                 .reserved(.semicolon),
                 .reserved(.braceRight)
             ]
@@ -102,7 +102,7 @@ final class ForTest: XCTestCase {
                 .reserved(.semicolon),
                 .reserved(.semicolon),
                 .reserved(.parenthesisRight),
-                .number("4"),
+                .integerLiteral("4"),
                 .reserved(.semicolon)
             ]
         )

--- a/Tests/ParserTest/Control/IfTest.swift
+++ b/Tests/ParserTest/Control/IfTest.swift
@@ -9,9 +9,9 @@ final class IfTest: XCTestCase {
             kinds: [
                 .keyword(.if),
                 .reserved(.parenthesisLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.parenthesisRight),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon),
                 .endOfFile
             ]
@@ -44,12 +44,12 @@ final class IfTest: XCTestCase {
             kinds: [
                 .keyword(.if),
                 .reserved(.parenthesisLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.parenthesisRight),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon),
                 .keyword(.else),
-                .number("3"),
+                .integerLiteral("3"),
                 .reserved(.semicolon),
                 .endOfFile
             ]

--- a/Tests/ParserTest/Control/WhileTest.swift
+++ b/Tests/ParserTest/Control/WhileTest.swift
@@ -9,9 +9,9 @@ final class WhileTest: XCTestCase {
             kinds: [
                 .keyword(.while),
                 .reserved(.parenthesisLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.parenthesisRight),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon),
                 .endOfFile
             ]
@@ -44,7 +44,7 @@ final class WhileTest: XCTestCase {
                     kinds: [
                         .keyword(.while),
                         .reserved(.parenthesisLeft),
-                        .number("1"),
+                        .integerLiteral("1"),
                         .reserved(.parenthesisRight),
                         .reserved(.semicolon),
                         .endOfFile

--- a/Tests/ParserTest/EmptyTest.swift
+++ b/Tests/ParserTest/EmptyTest.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import Parser
+import Tokenizer
+
+final class EmptyTest: XCTestCase {
+
+    func testEmpty() throws {
+        let tokens: [Token] = buildTokens(
+            kinds: [
+                .endOfFile
+            ]
+        )
+        let node = try Parser(tokens: tokens).parse()
+
+        XCTAssertEqual(node.sourceTokens, tokens)
+
+        XCTAssertEqual(
+            node,
+            SourceFileNode(statements: [], endOfFile: TokenNode(token: tokens[0]))
+        )
+    }
+}

--- a/Tests/ParserTest/FunctionTest.swift
+++ b/Tests/ParserTest/FunctionTest.swift
@@ -12,9 +12,9 @@ final class FunctionTest: XCTestCase {
                 .reserved(.parenthesisLeft),
                 .reserved(.parenthesisRight),
                 .reserved(.braceLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.semicolon),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon),
                 .reserved(.braceRight),
                 .endOfFile
@@ -60,9 +60,9 @@ final class FunctionTest: XCTestCase {
                 .reserved(.parenthesisLeft),
                 .reserved(.parenthesisRight),
                 .reserved(.braceLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.semicolon),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon),
                 .reserved(.braceRight),
                 .endOfFile
@@ -139,7 +139,7 @@ final class FunctionTest: XCTestCase {
                 .identifier("b"),
                 .reserved(.parenthesisRight),
                 .reserved(.braceLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.semicolon),
                 .reserved(.braceRight),
                 .endOfFile
@@ -183,7 +183,7 @@ final class FunctionTest: XCTestCase {
             kinds: [
                 .identifier("main"),
                 .reserved(.parenthesisLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.comma),
                 .identifier("a"),
                 .reserved(.parenthesisRight),
@@ -222,7 +222,7 @@ final class FunctionTest: XCTestCase {
                 .reserved(.parenthesisLeft),
                 .reserved(.parenthesisRight),
                 .reserved(.braceLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.semicolon),
                 .reserved(.braceRight),
                 .type(.int),
@@ -230,7 +230,7 @@ final class FunctionTest: XCTestCase {
                 .reserved(.parenthesisLeft),
                 .reserved(.parenthesisRight),
                 .reserved(.braceLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.semicolon),
                 .reserved(.braceRight),
                 .endOfFile
@@ -287,7 +287,7 @@ final class FunctionTest: XCTestCase {
             kinds: [
                 .identifier("a"),
                 .reserved(.squareLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.squareRight),
                 .reserved(.semicolon)
             ]
@@ -315,7 +315,7 @@ final class FunctionTest: XCTestCase {
             kinds: [
                 .identifier("a"),
                 .reserved(.squareLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.add),
                 .identifier("b"),
                 .reserved(.squareRight),

--- a/Tests/ParserTest/OperatorPriorityTest.swift
+++ b/Tests/ParserTest/OperatorPriorityTest.swift
@@ -7,11 +7,11 @@ final class OperatorPriorityTest: XCTestCase {
     func testAddPriority() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.add),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.add),
-                .number("3"),
+                .integerLiteral("3"),
                 .reserved(.semicolon)
             ]
         )
@@ -39,11 +39,11 @@ final class OperatorPriorityTest: XCTestCase {
     func testMulPriority() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.mul),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.mul),
-                .number("3"),
+                .integerLiteral("3"),
                 .reserved(.semicolon)
             ]
         )
@@ -71,11 +71,11 @@ final class OperatorPriorityTest: XCTestCase {
     func testAddAndMulPriority() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.add),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.mul),
-                .number("3"),
+                .integerLiteral("3"),
                 .reserved(.semicolon)
             ]
         )
@@ -104,12 +104,12 @@ final class OperatorPriorityTest: XCTestCase {
         let tokens: [Token] = buildTokens(
             kinds: [
                 .reserved(.parenthesisLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.add),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.parenthesisRight),
                 .reserved(.mul),
-                .number("3"),
+                .integerLiteral("3"),
                 .reserved(.semicolon)
             ]
         )

--- a/Tests/ParserTest/OperatorsTest.swift
+++ b/Tests/ParserTest/OperatorsTest.swift
@@ -7,9 +7,9 @@ final class OperatorsTest: XCTestCase {
     func testAdd() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.add),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon)
             ]
         )
@@ -33,9 +33,9 @@ final class OperatorsTest: XCTestCase {
     func testSub() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.sub),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon)
             ]
         )
@@ -59,9 +59,9 @@ final class OperatorsTest: XCTestCase {
     func testMul() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.mul),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon)
             ]
         )
@@ -85,9 +85,9 @@ final class OperatorsTest: XCTestCase {
     func testDiv() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.div),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon)
             ]
         )
@@ -112,7 +112,7 @@ final class OperatorsTest: XCTestCase {
         let tokens: [Token] = buildTokens(
             kinds: [
                 .reserved(.add),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.semicolon)
             ]
         )
@@ -136,7 +136,7 @@ final class OperatorsTest: XCTestCase {
         let tokens: [Token] = buildTokens(
             kinds: [
                 .reserved(.sub),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.semicolon)
             ]
         )
@@ -207,9 +207,9 @@ final class OperatorsTest: XCTestCase {
     func testEqual() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.equal),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon)
             ]
         )
@@ -233,9 +233,9 @@ final class OperatorsTest: XCTestCase {
     func testNotEqual() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.notEqual),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon)
             ]
         )
@@ -259,9 +259,9 @@ final class OperatorsTest: XCTestCase {
     func testGreaterThan() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.greaterThan),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon)
             ]
         )
@@ -285,9 +285,9 @@ final class OperatorsTest: XCTestCase {
     func testGreaterThanOrEqual() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.greaterThanOrEqual),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon)
             ]
         )
@@ -311,9 +311,9 @@ final class OperatorsTest: XCTestCase {
     func testLessThan() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.lessThan),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon)
             ]
         )
@@ -337,9 +337,9 @@ final class OperatorsTest: XCTestCase {
     func testLessThanOrEqual() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.lessThanOrEqual),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon)
             ]
         )
@@ -366,7 +366,7 @@ final class OperatorsTest: XCTestCase {
             kinds: [
                 .keyword(.sizeof),
                 .reserved(.parenthesisLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.parenthesisRight),
                 .reserved(.semicolon)
             ]

--- a/Tests/ParserTest/ParseErrorTest.swift
+++ b/Tests/ParserTest/ParseErrorTest.swift
@@ -16,25 +16,10 @@ final class ParseErrorTest: XCTestCase {
                     ]
                 )
             ).stmt()
+
+            XCTFail()
         } catch let error as ParseError {
             XCTAssertEqual(error, .invalidSyntax(location: SourceLocation(line: 1, column: 3)))
-        }
-    }
-
-    func testInvalidPosition() throws {
-        do {
-            _ = try Parser(
-                tokens: buildTokens(
-                    kinds: [
-                        .reserved(.mul),
-                        .number("1"),
-                        .reserved(.semicolon),
-                        .endOfFile
-                    ]
-                )
-            ).stmt()
-        } catch let error as ParseError {
-            XCTAssertEqual(error, .invalidSyntax(location: SourceLocation(line: 1, column: 1)))
         }
     }
 
@@ -45,23 +30,17 @@ final class ParseErrorTest: XCTestCase {
                     kinds: [
                         .number("1"),
                         .reserved(.add),
-                        .reserved(.mul),
+                        .reserved(.div),
                         .number("2"),
                         .reserved(.semicolon),
                         .endOfFile
                     ]
                 )
             ).stmt()
+
+            XCTFail()
         } catch let error as ParseError {
             XCTAssertEqual(error, .invalidSyntax(location: SourceLocation(line: 1, column: 3)))
-        }
-    }
-
-    func testEmpty() throws {
-        do {
-            _ = try Parser(tokens: []).parse()
-        } catch let error as ParseError {
-            XCTAssertEqual(error, .invalidSyntax(location: SourceLocation(line: 1, column: 1)))
         }
     }
 
@@ -77,6 +56,8 @@ final class ParseErrorTest: XCTestCase {
                     ]
                 )
             ).stmt()
+
+            XCTFail()
         } catch let error as ParseError {
             XCTAssertEqual(error, .invalidSyntax(location: SourceLocation(line: 1, column: 4)))
         }

--- a/Tests/ParserTest/ParseErrorTest.swift
+++ b/Tests/ParserTest/ParseErrorTest.swift
@@ -9,7 +9,7 @@ final class ParseErrorTest: XCTestCase {
             _ = try Parser(
                 tokens: buildTokens(
                     kinds: [
-                        .number("1"),
+                        .integerLiteral("1"),
                         .reserved(.add),
                         .reserved(.semicolon),
                         .endOfFile
@@ -28,10 +28,10 @@ final class ParseErrorTest: XCTestCase {
             _ = try Parser(
                 tokens: buildTokens(
                     kinds: [
-                        .number("1"),
+                        .integerLiteral("1"),
                         .reserved(.add),
                         .reserved(.div),
-                        .number("2"),
+                        .integerLiteral("2"),
                         .reserved(.semicolon),
                         .endOfFile
                     ]
@@ -49,9 +49,9 @@ final class ParseErrorTest: XCTestCase {
             _ = try Parser(
                 tokens: buildTokens(
                     kinds: [
-                        .number("1"),
+                        .integerLiteral("1"),
                         .reserved(.add),
-                        .number("2"),
+                        .integerLiteral("2"),
                         .endOfFile
                     ]
                 )

--- a/Tests/ParserTest/ReturnTest.swift
+++ b/Tests/ParserTest/ReturnTest.swift
@@ -8,7 +8,7 @@ final class ReturnTest: XCTestCase {
         let tokens: [Token] = buildTokens(
             kinds: [
                 .keyword(.return),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.semicolon),
                 .endOfFile
             ]

--- a/Tests/ParserTest/VariableTest.swift
+++ b/Tests/ParserTest/VariableTest.swift
@@ -35,7 +35,7 @@ final class VariableTest: XCTestCase {
                 .type(.int),
                 .identifier("a"),
                 .reserved(.assign),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.semicolon),
                 .endOfFile
             ]
@@ -127,7 +127,7 @@ final class VariableTest: XCTestCase {
                 .type(.int),
                 .identifier("a"),
                 .reserved(.squareLeft),
-                .number("4"),
+                .integerLiteral("4"),
                 .reserved(.squareRight),
                 .reserved(.semicolon),
                 .endOfFile
@@ -159,13 +159,13 @@ final class VariableTest: XCTestCase {
                 .type(.int),
                 .identifier("a"),
                 .reserved(.squareLeft),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.squareRight),
                 .reserved(.assign),
                 .reserved(.braceLeft),
-                .number("1"),
+                .integerLiteral("1"),
                 .reserved(.comma),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.braceRight),
                 .reserved(.semicolon),
                 .endOfFile
@@ -206,7 +206,7 @@ final class VariableTest: XCTestCase {
                 .type(.char),
                 .identifier("a"),
                 .reserved(.squareLeft),
-                .number("2"),
+                .integerLiteral("2"),
                 .reserved(.squareRight),
                 .reserved(.assign),
                 .stringLiteral("ai"),
@@ -243,7 +243,7 @@ final class VariableTest: XCTestCase {
                 .reserved(.mul),
                 .identifier("a"),
                 .reserved(.squareLeft),
-                .number("4"),
+                .integerLiteral("4"),
                 .reserved(.squareRight),
                 .reserved(.semicolon),
                 .endOfFile

--- a/Tests/TokenizerTest/KeywordsTest.swift
+++ b/Tests/TokenizerTest/KeywordsTest.swift
@@ -37,7 +37,7 @@ final class KeywordsTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 7))
                 ),
                 Token(
-                    kind: .number("2"),
+                    kind: .integerLiteral("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 8), end: SourceLocation(line: 1, column: 9))
                 ),
                 Token(
@@ -129,7 +129,7 @@ final class KeywordsTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 5))
                 ),
                 Token(
@@ -142,7 +142,7 @@ final class KeywordsTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 6), end: SourceLocation(line: 1, column: 10))
                 ),
                 Token(
-                    kind: .number("2"),
+                    kind: .integerLiteral("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 11), end: SourceLocation(line: 1, column: 12))
                 ),
                 Token(
@@ -170,7 +170,7 @@ final class KeywordsTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 6), end: SourceLocation(line: 1, column: 7))
                 ),
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 7), end: SourceLocation(line: 1, column: 8))
                 ),
                 Token(
@@ -202,7 +202,7 @@ final class KeywordsTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 5))
                 ),
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 5), end: SourceLocation(line: 1, column: 6))
                 ),
                 Token(
@@ -210,7 +210,7 @@ final class KeywordsTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 6), end: SourceLocation(line: 1, column: 7))
                 ),
                 Token(
-                    kind: .number("2"),
+                    kind: .integerLiteral("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 7), end: SourceLocation(line: 1, column: 8))
                 ),
                 Token(
@@ -218,7 +218,7 @@ final class KeywordsTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 8), end: SourceLocation(line: 1, column: 9))
                 ),
                 Token(
-                    kind: .number("3"),
+                    kind: .integerLiteral("3"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 9), end: SourceLocation(line: 1, column: 10))
                 ),
                 Token(
@@ -250,7 +250,7 @@ final class KeywordsTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 7), end: SourceLocation(line: 1, column: 8))
                 ),
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 8), end: SourceLocation(line: 1, column: 9))
                 ),
                 Token(

--- a/Tests/TokenizerTest/NumberTest.swift
+++ b/Tests/TokenizerTest/NumberTest.swift
@@ -1,9 +1,9 @@
 import XCTest
 @testable import Tokenizer
 
-final class NumberTest: XCTestCase {
+final class IntegerLiteralTest: XCTestCase {
 
-    func testNumber() throws {
+    func testIntegerLiteral() throws {
         let source = "5"
         let tokens = try Tokenizer(source: source).tokenize()
 
@@ -12,7 +12,7 @@ final class NumberTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("5"),
+                    kind: .integerLiteral("5"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
@@ -23,7 +23,7 @@ final class NumberTest: XCTestCase {
         )
     }
 
-    func testNumberMultitoken() throws {
+    func testIntegerLiteralMulti() throws {
         let source = "123"
         let tokens = try Tokenizer(source: source).tokenize()
 
@@ -32,7 +32,7 @@ final class NumberTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("123"),
+                    kind: .integerLiteral("123"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(

--- a/Tests/TokenizerTest/TokenSpecTest.swift
+++ b/Tests/TokenizerTest/TokenSpecTest.swift
@@ -7,6 +7,13 @@ final class TokenSpecTest: XCTestCase {
             let spec = TokenSpec.reserved(kind)
             let token = Token(kind: .reserved(kind), sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))
             XCTAssert(spec ~= token)
+
+            XCTAssertFalse(TokenSpec.keyword(.if) ~= token)
+            XCTAssertFalse(TokenSpec.integerLiteral ~= token)
+            XCTAssertFalse(TokenSpec.stringLiteral ~= token)
+            XCTAssertFalse(TokenSpec.identifier ~= token)
+            XCTAssertFalse(TokenSpec.type ~= token)
+            XCTAssertFalse(TokenSpec.endOfFile ~= token)
         }
     }
 
@@ -15,6 +22,13 @@ final class TokenSpecTest: XCTestCase {
             let spec = TokenSpec.keyword(kind)
             let token = Token(kind: .keyword(kind), sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))
             XCTAssert(spec ~= token)
+
+            XCTAssertFalse(TokenSpec.reserved(.add) ~= token)
+            XCTAssertFalse(TokenSpec.integerLiteral ~= token)
+            XCTAssertFalse(TokenSpec.stringLiteral ~= token)
+            XCTAssertFalse(TokenSpec.identifier ~= token)
+            XCTAssertFalse(TokenSpec.type ~= token)
+            XCTAssertFalse(TokenSpec.endOfFile ~= token)
         }
     }
 
@@ -22,18 +36,39 @@ final class TokenSpecTest: XCTestCase {
         let spec = TokenSpec.integerLiteral
         let token = Token(kind: .integerLiteral("1"), sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))
         XCTAssert(spec ~= token)
+
+        XCTAssertFalse(TokenSpec.reserved(.add) ~= token)
+        XCTAssertFalse(TokenSpec.keyword(.if) ~= token)
+        XCTAssertFalse(TokenSpec.stringLiteral ~= token)
+        XCTAssertFalse(TokenSpec.identifier ~= token)
+        XCTAssertFalse(TokenSpec.type ~= token)
+        XCTAssertFalse(TokenSpec.endOfFile ~= token)
     }
 
     func testStringLiteral() {
         let spec = TokenSpec.stringLiteral
         let token = Token(kind: .stringLiteral("a"), sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))
         XCTAssert(spec ~= token)
+
+        XCTAssertFalse(TokenSpec.reserved(.add) ~= token)
+        XCTAssertFalse(TokenSpec.keyword(.if) ~= token)
+        XCTAssertFalse(TokenSpec.integerLiteral ~= token)
+        XCTAssertFalse(TokenSpec.identifier ~= token)
+        XCTAssertFalse(TokenSpec.type ~= token)
+        XCTAssertFalse(TokenSpec.endOfFile ~= token)
     }
 
     func testIdentifier() {
         let spec = TokenSpec.identifier
         let token = Token(kind: .identifier("a"), sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))
         XCTAssert(spec ~= token)
+
+        XCTAssertFalse(TokenSpec.reserved(.add) ~= token)
+        XCTAssertFalse(TokenSpec.keyword(.if) ~= token)
+        XCTAssertFalse(TokenSpec.integerLiteral ~= token)
+        XCTAssertFalse(TokenSpec.stringLiteral ~= token)
+        XCTAssertFalse(TokenSpec.type ~= token)
+        XCTAssertFalse(TokenSpec.endOfFile ~= token)
     }
 
     func testType() {
@@ -41,6 +76,12 @@ final class TokenSpecTest: XCTestCase {
             let spec = TokenSpec.type
             let token = Token(kind: .type(kind), sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))
             XCTAssert(spec ~= token)
+
+            XCTAssertFalse(TokenSpec.reserved(.add) ~= token)
+            XCTAssertFalse(TokenSpec.keyword(.if) ~= token)
+            XCTAssertFalse(TokenSpec.integerLiteral ~= token)
+            XCTAssertFalse(TokenSpec.stringLiteral ~= token)
+            XCTAssertFalse(TokenSpec.endOfFile ~= token)
         }
     }
 
@@ -48,5 +89,11 @@ final class TokenSpecTest: XCTestCase {
         let spec = TokenSpec.endOfFile
         let token = Token(kind: .endOfFile, sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))
         XCTAssert(spec ~= token)
+
+        XCTAssertFalse(TokenSpec.reserved(.add) ~= token)
+        XCTAssertFalse(TokenSpec.keyword(.if) ~= token)
+        XCTAssertFalse(TokenSpec.integerLiteral ~= token)
+        XCTAssertFalse(TokenSpec.stringLiteral ~= token)
+        XCTAssertFalse(TokenSpec.type ~= token)
     }
 }

--- a/Tests/TokenizerTest/TokenSpecTest.swift
+++ b/Tests/TokenizerTest/TokenSpecTest.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Tokenizer
+
+final class TokenSpecTest: XCTestCase {
+    func testReserved() {
+        for kind in ReservedKind.allCases {
+            let spec = TokenSpec.reserved(kind)
+            let token = Token(kind: .reserved(kind), sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))
+            XCTAssert(spec ~= token)
+        }
+    }
+
+    func testKeywords() {
+        for kind in KeywordKind.allCases {
+            let spec = TokenSpec.keyword(kind)
+            let token = Token(kind: .keyword(kind), sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))
+            XCTAssert(spec ~= token)
+        }
+    }
+
+    func testIntegerLiteral() {
+        let spec = TokenSpec.integerLiteral
+        let token = Token(kind: .integerLiteral("1"), sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))
+        XCTAssert(spec ~= token)
+    }
+
+    func testStringLiteral() {
+        let spec = TokenSpec.stringLiteral
+        let token = Token(kind: .stringLiteral("a"), sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))
+        XCTAssert(spec ~= token)
+    }
+
+    func testIdentifier() {
+        let spec = TokenSpec.identifier
+        let token = Token(kind: .identifier("a"), sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))
+        XCTAssert(spec ~= token)
+    }
+
+    func testType() {
+        for kind in TypeKind.allCases {
+            let spec = TokenSpec.type
+            let token = Token(kind: .type(kind), sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))
+            XCTAssert(spec ~= token)
+        }
+    }
+
+    func testEndOfFile() {
+        let spec = TokenSpec.endOfFile
+        let token = Token(kind: .endOfFile, sourceRange: SourceRange(start: .startOfFile, end: .startOfFile))
+        XCTAssert(spec ~= token)
+    }
+}

--- a/Tests/TokenizerTest/TokensTest.swift
+++ b/Tests/TokenizerTest/TokensTest.swift
@@ -11,7 +11,7 @@ final class TokensTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
@@ -19,7 +19,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 3))
                 ),
                 Token(
-                    kind: .number("2"),
+                    kind: .integerLiteral("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
@@ -39,7 +39,7 @@ final class TokensTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
@@ -47,7 +47,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 3))
                 ),
                 Token(
-                    kind: .number("2"),
+                    kind: .integerLiteral("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
@@ -67,7 +67,7 @@ final class TokensTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
@@ -75,7 +75,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 3))
                 ),
                 Token(
-                    kind: .number("2"),
+                    kind: .integerLiteral("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
@@ -95,7 +95,7 @@ final class TokensTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
@@ -103,7 +103,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 3))
                 ),
                 Token(
-                    kind: .number("2"),
+                    kind: .integerLiteral("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
@@ -151,7 +151,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 3))
                 ),
                 Token(
@@ -179,7 +179,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 3))
                 ),
                 Token(
@@ -207,7 +207,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 3))
                 ),
                 Token(
@@ -235,7 +235,7 @@ final class TokensTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
@@ -243,7 +243,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
-                    kind: .number("2"),
+                    kind: .integerLiteral("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 5))
                 ),
                 Token(
@@ -263,7 +263,7 @@ final class TokensTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
@@ -271,7 +271,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
-                    kind: .number("2"),
+                    kind: .integerLiteral("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 5))
                 ),
                 Token(
@@ -291,7 +291,7 @@ final class TokensTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
@@ -299,7 +299,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 3))
                 ),
                 Token(
-                    kind: .number("2"),
+                    kind: .integerLiteral("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
@@ -319,7 +319,7 @@ final class TokensTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
@@ -327,7 +327,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
-                    kind: .number("2"),
+                    kind: .integerLiteral("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 5))
                 ),
                 Token(
@@ -347,7 +347,7 @@ final class TokensTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
@@ -355,7 +355,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 3))
                 ),
                 Token(
-                    kind: .number("2"),
+                    kind: .integerLiteral("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
@@ -375,7 +375,7 @@ final class TokensTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
@@ -383,7 +383,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
-                    kind: .number("2"),
+                    kind: .integerLiteral("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 4), end: SourceLocation(line: 1, column: 5))
                 ),
                 Token(
@@ -411,7 +411,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 3))
                 ),
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
@@ -431,7 +431,7 @@ final class TokensTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
@@ -455,7 +455,7 @@ final class TokensTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
                 Token(
@@ -463,7 +463,7 @@ final class TokensTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 2), end: SourceLocation(line: 1, column: 3))
                 ),
                 Token(
-                    kind: .number("2"),
+                    kind: .integerLiteral("2"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(

--- a/Tests/TokenizerTest/WhiteSpaceTest.swift
+++ b/Tests/TokenizerTest/WhiteSpaceTest.swift
@@ -12,7 +12,7 @@ final class WhiteSpaceTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     trailingTrivia: " ",
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
@@ -22,7 +22,7 @@ final class WhiteSpaceTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
-                    kind: .number("23"),
+                    kind: .integerLiteral("23"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 7), end: SourceLocation(line: 1, column: 9))
                 ),
                 Token(
@@ -42,7 +42,7 @@ final class WhiteSpaceTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     trailingTrivia: " ",
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
@@ -52,7 +52,7 @@ final class WhiteSpaceTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
-                    kind: .number("23"),
+                    kind: .integerLiteral("23"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 6), end: SourceLocation(line: 1, column: 8))
                 ),
                 Token(
@@ -72,7 +72,7 @@ final class WhiteSpaceTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     trailingTrivia: " ",
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
@@ -81,7 +81,7 @@ final class WhiteSpaceTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
-                    kind: .number("23"),
+                    kind: .integerLiteral("23"),
                     leadingTrivia: "\n",
                     sourceRange: SourceRange(start: SourceLocation(line: 2, column: 1), end: SourceLocation(line: 2, column: 3))
                 ),
@@ -102,7 +102,7 @@ final class WhiteSpaceTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     trailingTrivia: " ",
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
@@ -112,7 +112,7 @@ final class WhiteSpaceTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
-                    kind: .number("23"),
+                    kind: .integerLiteral("23"),
                     leadingTrivia: "\n ",
                     sourceRange: SourceRange(start: SourceLocation(line: 2, column: 2), end: SourceLocation(line: 2, column: 4))
                 ),
@@ -133,7 +133,7 @@ final class WhiteSpaceTest: XCTestCase {
             tokens,
             [
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     trailingTrivia: " ",
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 2))
                 ),
@@ -143,7 +143,7 @@ final class WhiteSpaceTest: XCTestCase {
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
-                    kind: .number("23"),
+                    kind: .integerLiteral("23"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 15), end: SourceLocation(line: 1, column: 17))
                 ),
                 Token(
@@ -176,7 +176,7 @@ a = 1
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 3), end: SourceLocation(line: 1, column: 4))
                 ),
                 Token(
-                    kind: .number("1"),
+                    kind: .integerLiteral("1"),
                     sourceRange: SourceRange(start: SourceLocation(line: 1, column: 5), end: SourceLocation(line: 1, column: 6))
                 ),
                 Token(

--- a/Tests/TokenizerTest/WhiteSpaceTest.swift
+++ b/Tests/TokenizerTest/WhiteSpaceTest.swift
@@ -187,4 +187,20 @@ a = 1
             ]
         )
     }
+
+    func testEmpty() throws {
+        let source = ""
+        let tokens = try Tokenizer(source: source).tokenize()
+
+        XCTAssertEqual(tokens.reduce("") { $0 + $1.description }, source)
+        XCTAssertEqual(
+            tokens,
+            [
+                Token(
+                    kind: .endOfFile,
+                    sourceRange: SourceRange(start: SourceLocation(line: 1, column: 1), end: SourceLocation(line: 1, column: 1))
+                )
+            ]
+        )
+    }
 }


### PR DESCRIPTION
# 概要
- Parserでtokenを扱う際に、`tokens[index].kind == ...`のように利用していた
- より可読性高く簡潔に記述するため、操作メソッド経由で操作する

# 実装
- `TokenSpec`: TokenKindからassociated valuesを抜いた比較用の型
    - SwiftSyntaxとはやや異なる
    - SwiftSyntaxでは`TokenSpec`は`RawTokenKind`を持っており、`RawTokenKind`にassociated valuesがないのでこれを使える
- `consume(if: TokenSpec) -> TokenNode?`
    - `if let identifier = consume(if: )`や`while let identifier = consume(if: )`と書ける
- `consume(_: TokenSpec) throws -> TokenNode`
    - SwiftSyntaxでは`eat` (?)
- `at(_: TokenSpec) -> Bool`
- `peek() -> Token?`
    - 使い所がわからない