### PR TITLE
CSTの配列表現を見直す

### DIFF
--- a/Sources/Parser/Syntax/StatementSyntax.swift
+++ b/Sources/Parser/Syntax/StatementSyntax.swift
@@ -209,19 +209,33 @@ public class VariableDeclSyntax: SyntaxProtocol {
 
     public let kind: SyntaxKind = .variableDecl
     public var children: [any SyntaxProtocol] {
-        [type, identifier, equal, initializerExpr].compactMap { $0 }
+        [type, identifier, squareLeft, arrayLength, squareRight, equal, initializerExpr].compactMap { $0 }
     }
 
     public let type: any TypeSyntaxProtocol
     public let identifier: TokenSyntax
+    public let squareLeft: TokenSyntax?
+    public let arrayLength: TokenSyntax?
+    public let squareRight: TokenSyntax?
     public let equal: TokenSyntax?
     public let initializerExpr: (any SyntaxProtocol)?
 
     // MARK: - Initializer
 
-    public init(type: any TypeSyntaxProtocol, identifier: TokenSyntax, equal: TokenSyntax? = nil, initializerExpr: (any SyntaxProtocol)? = nil) {
+    public init(
+        type: any TypeSyntaxProtocol,
+        identifier: TokenSyntax,
+        squareLeft: TokenSyntax? = nil,
+        arrayLength: TokenSyntax? = nil,
+        squareRight: TokenSyntax? = nil,
+        equal: TokenSyntax? = nil,
+        initializerExpr: (any SyntaxProtocol)? = nil
+    ) {
         self.type = type
         self.identifier = identifier
+        self.squareLeft = squareLeft
+        self.arrayLength = arrayLength
+        self.squareRight = squareRight
         self.equal = equal
         self.initializerExpr = initializerExpr
     }
@@ -233,18 +247,31 @@ public class FunctionParameterSyntax: SyntaxProtocol {
 
     public let kind: SyntaxKind = .functionParameter
     public var children: [any SyntaxProtocol] {
-        ([type, identifier, comma] as [(any SyntaxProtocol)?]).compactMap { $0 }
+        ([type, identifier, squareLeft, arrayLength, squareRight, comma] as [(any SyntaxProtocol)?]).compactMap { $0 }
     }
 
     public let type: any TypeSyntaxProtocol
     public let identifier: TokenSyntax
+    public let squareLeft: TokenSyntax?
+    public let arrayLength: TokenSyntax?
+    public let squareRight: TokenSyntax?
     public let comma: TokenSyntax?
 
     // MARK: - Initializer
 
-    public init(type: any TypeSyntaxProtocol, identifier: TokenSyntax, comma: TokenSyntax? = nil) {
+    public init(
+        type: any TypeSyntaxProtocol,
+        identifier: TokenSyntax,
+        squareLeft: TokenSyntax? = nil,
+        arrayLength: TokenSyntax? = nil,
+        squareRight: TokenSyntax? = nil,
+        comma: TokenSyntax? = nil
+    ) {
         self.type = type
         self.identifier = identifier
+        self.squareLeft = squareLeft
+        self.arrayLength = arrayLength
+        self.squareRight = squareRight
         self.comma = comma
     }
 }

--- a/Sources/Parser/Syntax/Syntax.swift
+++ b/Sources/Parser/Syntax/Syntax.swift
@@ -9,7 +9,6 @@ public enum SyntaxKind {
 
     case type
     case pointerType
-    case arrayType
     
     case prefixOperatorExpr
     case infixOperatorExpr

--- a/Sources/Parser/Syntax/TypeSyntax.swift
+++ b/Sources/Parser/Syntax/TypeSyntax.swift
@@ -40,27 +40,3 @@ public class PointerTypeSyntax: TypeSyntaxProtocol {
         self.pointer = pointer
     }
 }
-
-public class ArrayTypeSyntax: TypeSyntaxProtocol {
-
-    // MARK: - Property
-
-    public let kind: SyntaxKind = .arrayType
-    public var children: [any SyntaxProtocol] {
-        [elementType, squareLeft, arraySize, squareRight]
-    }
-
-    public let elementType: any TypeSyntaxProtocol
-    public let squareLeft: TokenSyntax
-    public let arraySize: TokenSyntax
-    public let squareRight: TokenSyntax
-
-    // MARK: - Initializer
-
-    public init(elementType: any TypeSyntaxProtocol, squareLeft: TokenSyntax, arraySize: TokenSyntax, squareRight: TokenSyntax) {
-        self.elementType = elementType
-        self.squareLeft = squareLeft
-        self.arraySize = arraySize
-        self.squareRight = squareRight
-    }
-}

--- a/Tests/ParserTest/FunctionTest.swift
+++ b/Tests/ParserTest/FunctionTest.swift
@@ -325,6 +325,87 @@ final class FunctionTest: XCTestCase {
         )
     }
 
+    func testFunctionCallWithArrayParameter() throws {
+        let tokens: [Token] = buildTokens(
+            kinds: [
+                .type(.int),
+                .identifier("main"),
+                .reserved(.parenthesisLeft),
+                .type(.int),
+                .identifier("a"),
+                .reserved(.squareLeft),
+                .reserved(.squareRight),
+                .reserved(.parenthesisRight),
+                .reserved(.braceLeft),
+                .reserved(.braceRight),
+                .endOfFile
+            ]
+        )
+        let syntax = try Parser(tokens: tokens).parse()
+
+        XCTAssertEqual(syntax.sourceTokens, tokens)
+
+        XCTAssertEqual(
+            syntax,
+            SourceFileSyntax(
+                statements: [
+                    BlockItemSyntax(
+                        item: FunctionDeclSyntax(
+                            returnType: TypeSyntax(type: TokenSyntax(token: tokens[0])),
+                            functionName: TokenSyntax(token: tokens[1]),
+                            parenthesisLeft: TokenSyntax(token: tokens[2]),
+                            parameters: [
+                                FunctionParameterSyntax(
+                                    type: TypeSyntax(type: TokenSyntax(token: tokens[3])),
+                                    identifier: TokenSyntax(token: tokens[4]),
+                                    squareLeft: TokenSyntax(token: tokens[5]),
+                                    squareRight: TokenSyntax(token: tokens[6])
+                                )
+                            ],
+                            parenthesisRight: TokenSyntax(token: tokens[7]),
+                            block: BlockStatementSyntax(
+                                braceLeft: TokenSyntax(token: tokens[8]),
+                                items: [],
+                                braceRight: TokenSyntax(token: tokens[9])
+                            )
+                        )
+                    )
+                ],
+                endOfFile: TokenSyntax(token: tokens[10])
+            )
+        )
+
+        let node = ASTGenerator.generate(syntax: syntax)
+
+        XCTAssertEqual(
+            node as! SourceFileNode,
+            SourceFileNode(
+                statements: [
+                    FunctionDeclNode(
+                        returnType: TypeNode(type: .int, sourceRange: tokens[0].sourceRange),
+                        functionName: tokens[1].text,
+                        parameters: [
+                            FunctionParameterNode(
+                                type: PointerTypeNode(
+                                    referenceType: TypeNode(type: .int, sourceRange: tokens[3].sourceRange),
+                                    sourceRange: tokens[3].sourceRange
+                                ),
+                                identifierName: tokens[4].text,
+                                sourceRange: SourceRange(start: tokens[3].sourceRange.start, end: tokens[6].sourceRange.end)
+                            )
+                        ],
+                        block: BlockStatementNode(
+                            items: [],
+                            sourceRange: SourceRange(start: tokens[8].sourceRange.start, end: tokens[9].sourceRange.end)
+                        ),
+                        sourceRange: SourceRange(start: tokens[0].sourceRange.start, end: tokens[9].sourceRange.end)
+                    )
+                ],
+                sourceRange: SourceRange(start: tokens[0].sourceRange.start, end: tokens[10].sourceRange.end)
+            )
+        )
+    }
+
     func testFunctionDecls() throws {
         let tokens: [Token] = buildTokens(
             kinds: [

--- a/Tests/ParserTest/VariableTest.swift
+++ b/Tests/ParserTest/VariableTest.swift
@@ -175,7 +175,6 @@ final class VariableTest: XCTestCase {
         )
     }
 
-    // FIXME: ArrayTypeのsourceTokenの順序がおかしくなる
     func testDeclVariableArray() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
@@ -190,24 +189,38 @@ final class VariableTest: XCTestCase {
         )
         let syntax = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(syntax.sourceTokens, tokens.dropLast())
+
         XCTAssertEqual(
             syntax,
             BlockItemSyntax(
                 item: VariableDeclSyntax(
-                    type: ArrayTypeSyntax(
-                        elementType: TypeSyntax(type: TokenSyntax(token: tokens[0])),
-                        squareLeft: TokenSyntax(token: tokens[2]),
-                        arraySize: TokenSyntax(token: tokens[3]),
-                        squareRight: TokenSyntax(token: tokens[4])
-                    ),
-                    identifier: TokenSyntax(token: tokens[1])
+                    type: TypeSyntax(type: TokenSyntax(token: tokens[0])),
+                    identifier: TokenSyntax(token: tokens[1]),
+                    squareLeft: TokenSyntax(token: tokens[2]),
+                    arrayLength: TokenSyntax(token: tokens[3]),
+                    squareRight: TokenSyntax(token: tokens[4])
                 ),
                 semicolon: TokenSyntax(token: tokens[5])
             )
         )
+
+        let node = ASTGenerator.generate(syntax: syntax)
+
+        XCTAssertEqual(
+            node as! VariableDeclNode,
+            VariableDeclNode(
+                type: ArrayTypeNode(
+                    elementType: TypeNode(type: .int, sourceRange: tokens[0].sourceRange), 
+                    arrayLength: Int(tokens[3].text)!,
+                    sourceRange: tokens[0].sourceRange
+                ),
+                identifierName: tokens[1].text,
+                sourceRange: SourceRange(start: tokens[0].sourceRange.start, end: tokens[4].sourceRange.end)
+            )
+        )
     }
 
-    // FIXME: ArrayTypeのsourceTokenの順序がおかしくなる
     func testDeclAndInitVariableArray() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
@@ -228,17 +241,17 @@ final class VariableTest: XCTestCase {
         )
         let syntax = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(syntax.sourceTokens, tokens.dropLast())
+
         XCTAssertEqual(
             syntax,
             BlockItemSyntax(
                 item: VariableDeclSyntax(
-                    type: ArrayTypeSyntax(
-                        elementType: TypeSyntax(type: TokenSyntax(token: tokens[0])),
-                        squareLeft: TokenSyntax(token: tokens[2]),
-                        arraySize: TokenSyntax(token: tokens[3]),
-                        squareRight: TokenSyntax(token: tokens[4])
-                    ),
+                    type: TypeSyntax(type: TokenSyntax(token: tokens[0])),
                     identifier: TokenSyntax(token: tokens[1]),
+                    squareLeft: TokenSyntax(token: tokens[2]),
+                    arrayLength: TokenSyntax(token: tokens[3]),
+                    squareRight: TokenSyntax(token: tokens[4]),
                     equal: TokenSyntax(token: tokens[5]),
                     initializerExpr: InitListExprSyntax(
                         braceLeft: TokenSyntax(token: tokens[6]),
@@ -252,9 +265,36 @@ final class VariableTest: XCTestCase {
                 semicolon: TokenSyntax(token: tokens[11])
             )
         )
+
+        let node = ASTGenerator.generate(syntax: syntax)
+
+        XCTAssertEqual(
+            node as! VariableDeclNode,
+            VariableDeclNode(
+                type: ArrayTypeNode(
+                    elementType: TypeNode(type: .int, sourceRange: tokens[0].sourceRange),
+                    arrayLength: Int(tokens[3].text)!,
+                    sourceRange: tokens[0].sourceRange
+                ),
+                identifierName: tokens[1].text,
+                initializerExpr: InitListExprNode(
+                    expressions: [
+                        IntegerLiteralNode(
+                            literal: tokens[7].text,
+                            sourceRange: tokens[7].sourceRange
+                        ),
+                        IntegerLiteralNode(
+                            literal: tokens[9].text,
+                            sourceRange: tokens[9].sourceRange
+                        )
+                    ],
+                    sourceRange: SourceRange(start: tokens[6].sourceRange.start, end: tokens[10].sourceRange.end)
+                ),
+                sourceRange: SourceRange(start: tokens[0].sourceRange.start, end: tokens[10].sourceRange.end)
+            )
+        )
     }
 
-    // FIXME: ArrayTypeのsourceTokenの順序がおかしくなる
     func testDeclAndInitVariableStringLiteral() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
@@ -271,26 +311,41 @@ final class VariableTest: XCTestCase {
         )
         let syntax = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(syntax.sourceTokens, tokens.dropLast())
+
         XCTAssertEqual(
             syntax,
             BlockItemSyntax(
                 item: VariableDeclSyntax(
-                    type: ArrayTypeSyntax(
-                        elementType: TypeSyntax(type: TokenSyntax(token: tokens[0])),
-                        squareLeft: TokenSyntax(token: tokens[2]),
-                        arraySize: TokenSyntax(token: tokens[3]),
-                        squareRight: TokenSyntax(token: tokens[4])
-                    ),
+                    type: TypeSyntax(type: TokenSyntax(token: tokens[0])),
                     identifier: TokenSyntax(token: tokens[1]),
+                    squareLeft: TokenSyntax(token: tokens[2]),
+                    arrayLength: TokenSyntax(token: tokens[3]),
+                    squareRight: TokenSyntax(token: tokens[4]),
                     equal: TokenSyntax(token: tokens[5]),
                     initializerExpr: StringLiteralSyntax(literal: TokenSyntax(token: tokens[6]))
                 ),
                 semicolon: TokenSyntax(token: tokens[7])
             )
         )
+
+        let node = ASTGenerator.generate(syntax: syntax)
+
+        XCTAssertEqual(
+            node as! VariableDeclNode,
+            VariableDeclNode(
+                type: ArrayTypeNode(
+                    elementType: TypeNode(type: .int, sourceRange: tokens[0].sourceRange),
+                    arrayLength: Int(tokens[3].text)!,
+                    sourceRange: tokens[0].sourceRange
+                ),
+                identifierName: tokens[1].text,
+                initializerExpr: StringLiteralNode(literal: "ai", sourceRange: tokens[6].sourceRange),
+                sourceRange: SourceRange(start: tokens[0].sourceRange.start, end: tokens[6].sourceRange.end)
+            )
+        )
     }
 
-    // FIXME: ArrayTypeのsourceTokenの順序がおかしくなる
     func testDeclVariableArrayPointer() throws {
         let tokens: [Token] = buildTokens(
             kinds: [
@@ -306,19 +361,37 @@ final class VariableTest: XCTestCase {
         )
         let syntax = try Parser(tokens: tokens).stmt()
 
+        XCTAssertEqual(syntax.sourceTokens, tokens.dropLast())
+
         XCTAssertEqual(
             syntax,
             BlockItemSyntax(
                 item: VariableDeclSyntax(
-                    type: ArrayTypeSyntax(
-                        elementType: PointerTypeSyntax(referenceType: TypeSyntax(type: TokenSyntax(token: tokens[0])), pointer: TokenSyntax(token: tokens[1])),
-                        squareLeft: TokenSyntax(token: tokens[3]),
-                        arraySize: TokenSyntax(token: tokens[4]),
-                        squareRight: TokenSyntax(token: tokens[5])
-                    ),
-                    identifier: TokenSyntax(token: tokens[2])
+                    type: PointerTypeSyntax(referenceType: TypeSyntax(type: TokenSyntax(token: tokens[0])), pointer: TokenSyntax(token: tokens[1])),
+                    identifier: TokenSyntax(token: tokens[2]),
+                    squareLeft: TokenSyntax(token: tokens[3]),
+                    arrayLength: TokenSyntax(token: tokens[4]),
+                    squareRight: TokenSyntax(token: tokens[5])
                 ),
                 semicolon: TokenSyntax(token: tokens[6])
+            )
+        )
+
+        let node = ASTGenerator.generate(syntax: syntax)
+
+        XCTAssertEqual(
+            node as! VariableDeclNode,
+            VariableDeclNode(
+                type: ArrayTypeNode(
+                    elementType: PointerTypeNode(
+                        referenceType: TypeNode(type: .int, sourceRange: tokens[0].sourceRange),
+                        sourceRange: SourceRange(start: tokens[0].sourceRange.start, end: tokens[1].sourceRange.end)
+                    ),
+                    arrayLength: Int(tokens[4].text)!,
+                    sourceRange: SourceRange(start: tokens[0].sourceRange.start, end: tokens[1].sourceRange.end)
+                ),
+                identifierName: tokens[2].text,
+                sourceRange: SourceRange(start: tokens[0].sourceRange.start, end: tokens[5].sourceRange.end)
             )
         )
     }


### PR DESCRIPTION
# 概要
- `int a[5];`をパースした時、CSTでは`VariableDecl(ArrayTypeNode(TypeNode(.int)), "a")`のような構造で保持していた
    - CSTの`sourceTokens`で元のソースを出力するときに、`[5]`が`ArrayTypeNode`に含まれてしまうため位置が前後して問題になった
- CSTでArrayTypeNodeを廃止し、`VariableDecl(TypeNode(.int), "a", "[", "5", "]")`のように保持する
    - ASTで従来通りArrayTypeNodeに変換するためGenに影響なし

# 他の実装
`ArrayVariableDecl`を作成する
-  `[`, `5`, `]`などがOptionalではなくなり、型で制約できる

不採用理由
- `IfStatement`でも`else` `falseBody`はOptionalで扱っている
- 型を増やすと`VariableDeclProtocol`, `FunctionParameterProtocol`のような共通Protocolが必要になり複雑になるため