### PR TITLE
Genとアセンブリ出力の機能を分離する

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/CCompiler.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/CCompiler.xcscheme
@@ -101,6 +101,16 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "GeneratorTest"
+               BuildableName = "GeneratorTest"
+               BlueprintName = "GeneratorTest"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Package.swift
+++ b/Package.swift
@@ -57,6 +57,10 @@ let package = Package(
             dependencies: ["CCompilerCore"]
         ),
         .testTarget(
+            name: "GeneratorTest",
+            dependencies: ["Generator"]
+        ),
+        .testTarget(
             name: "ParserTest",
             dependencies: ["Parser", "AST"]
         ),

--- a/Sources/AST/ASTGenerator.swift
+++ b/Sources/AST/ASTGenerator.swift
@@ -218,7 +218,7 @@ public enum ASTGenerator {
     }
 
     static func generate(syntax: any SyntaxProtocol) -> any NodeProtocol {
-        return switch syntax.kind {
+        switch syntax.kind {
         case .integerLiteral: generate(integerLiteral: syntax.casted(IntegerLiteralSyntax.self))
         case .declReference: generate(declReference: syntax.casted(DeclReferenceSyntax.self))
         case .stringLiteral: generate(stringLiteral: syntax.casted(StringLiteralSyntax.self))

--- a/Sources/CCompilerCore/CCompilerCore.swift
+++ b/Sources/CCompilerCore/CCompilerCore.swift
@@ -15,8 +15,9 @@ public func compile(_ source: String) throws -> String {
         let tokens = try Tokenizer(source: source).tokenize()
         let syntax = try Parser(tokens: tokens).parse()
         let node = ASTGenerator.generate(sourceFileSyntax: syntax)
-
-        return try Generator().generate(sourceFileNode: node)
+        let asm = try Generator().generate(sourceFileNode: node)
+        
+        return ArmAsmPrinter.print(instructions: asm)
     } catch let error as TokenizeError {
         switch error {
         case .unknownToken(let location):

--- a/Sources/Generator/ArmAsmPrinter.swift
+++ b/Sources/Generator/ArmAsmPrinter.swift
@@ -1,0 +1,115 @@
+private extension AsmRepresent.Instruction.Address {
+    var description: String {
+        switch self {
+        case .register(let register): register.rawValue
+        case .distance(let register, let diff): "\(register.rawValue), #\(diff)"
+        }
+    }
+}
+
+public enum ArmAsmPrinter {
+    public static func print(instructions: [AsmRepresent.Instruction]) -> String {
+        instructions.map { print(instruction: $0) }.reduce("") { $0 + $1 }
+    }
+
+    static func print(instruction: AsmRepresent.Instruction) -> String {
+        func inst(opecode: String, a: AsmRepresent.Register, b: AsmRepresent.Register) -> String {
+            "    \(opecode) \(a.rawValue), \(b.rawValue)\n"
+        }
+
+        func inst(opecode: String, a: AsmRepresent.Register, immediate: String) -> String {
+            "    \(opecode) \(a.rawValue), #\(immediate)\n"
+        }
+
+        func inst(opecode: String, a: AsmRepresent.Register, b: AsmRepresent.Register, c: AsmRepresent.Register) -> String {
+            "    \(opecode) \(a.rawValue), \(b.rawValue), \(c.rawValue)\n"
+        }
+
+        func inst(opecode: String, a: AsmRepresent.Register, b: AsmRepresent.Register, immediate: String) -> String {
+            "    \(opecode) \(a.rawValue), \(b.rawValue), #\(immediate)\n"
+        }
+
+        func inst(opecode: String, a: AsmRepresent.Register, address: AsmRepresent.Instruction.Address) -> String {
+            "    \(opecode) \(a.rawValue), [\(address.description)]\n"
+        }
+
+        func inst(opecode: String, a: AsmRepresent.Register, b: AsmRepresent.Register, address: AsmRepresent.Instruction.Address) -> String {
+            "    \(opecode) \(a.rawValue), \(b.rawValue), [\(address.description)]\n"
+        }
+
+        func inst(opecode: String, label: String) -> String {
+            "    \(opecode) \(label)\n"
+        }
+
+        return switch instruction {
+        case .mov(let dst, let src): 
+            inst(opecode: "mov", a: dst, b: src)
+        case .movi(let dst, let immediate): 
+            inst(opecode: "mov", a: dst, immediate: immediate.description)
+        case .add(let dst, let src1, let src2): 
+            inst(opecode: "add", a: dst, b: src1, c: src2)
+        case .addi(let dst, let src, let immediate):
+            inst(opecode: "add", a: dst, b: src, immediate: immediate.description)
+        case .sub(let dst, let src1, let src2):
+            inst(opecode: "sub", a: dst, b: src1, c: src2)
+        case .subi(let dst, let src, let immediate):
+            inst(opecode: "sub", a: dst, b: src, immediate: immediate.description)
+        case .mul(let dst, let src1, let src2):
+            inst(opecode: "mul", a: dst, b: src1, c: src2)
+        case .muli(let dst, let src, let immediate):
+            inst(opecode: "mul", a: dst, b: src, immediate: immediate.description)
+        case .div(let dst, let src1, let src2):
+            inst(opecode: "sdiv", a: dst, b: src1, c: src2)
+        case .divi(let dst, let src, let immediate):
+            inst(opecode: "sdiv", a: dst, b: src, immediate: immediate.description)
+        case .push(let src):
+            "    str \(src.rawValue), [sp, #-16]!\n"
+        case .pop(let dst):
+            inst(opecode: "ldr", a: dst, address: .register(.sp))
+            + inst(opecode: "add", a: .sp, b: .sp, immediate: "16")
+        case .addr(let dst, let label):
+            "    adrp \(dst.rawValue), \(label)@GOTPAGE\n"
+            + "    ldr \(dst.rawValue), [\(dst.rawValue), \(label)@GOTPAGEOFF]\n"
+        case .str(let src, let address):
+            inst(opecode: "str", a: src, address: address)
+        case .strb(let src, let address):
+            inst(opecode: "strb", a: src, address: address)
+        case .stp(let src1, let src2, let address):
+            inst(opecode: "stp", a: src1, b: src2, address: address)
+        case .ldr(let dst, let address):
+            inst(opecode: "ldr", a: dst, address: address)
+        case .ldrb(let dst, let address):
+            inst(opecode: "ldrb", a: dst, address: address)
+        case .ldp(let dst1, let dst2, let address):
+            inst(opecode: "ldp", a: dst1, b: dst2, address: address)
+        case .cmp(let src1, let src2):
+            inst(opecode: "cmp", a: src1, b: src2)
+        case .cmpi(let src, let immediate):
+            inst(opecode: "cmp", a: src, immediate: immediate.description)
+        case .cset(let dst, let flag):
+            "    cset \(dst.rawValue), \(flag.rawValue)\n"
+        case .beq(let label):
+            inst(opecode: "beq", label: label == "main" ? "_main" : label)
+        case .b(let label):
+            inst(opecode: "b", label: label == "main" ? "_main" : label)
+        case .bl(let label):
+            inst(opecode: "bl", label: label == "main" ? "_main" : label)
+        case .neg(let dst, let src):
+            inst(opecode: "neg", a: dst, b: src)
+        case .lsli(let dst, let src, let immediate):
+            inst(opecode: "lsl", a: dst, b: src, immediate: immediate.description)
+        case .ret:
+            "    ret\n"
+        case .label(let label):
+            "\(label == "main" ? "_main" : label):\n"
+        case .p2align(let factor):
+            ".p2align \(factor)\n"
+        case .section(let kinds):
+            ".section \(kinds.map { $0.rawValue }.joined(separator: ","))\n"
+        case .globl(let label):
+            ".globl \(label == "main" ? "_main" : label)\n"
+        case .dataDecl(let kind, let value):
+            "    .\(kind.rawValue) \(value)\n"
+        }
+    }
+}

--- a/Sources/Generator/ArmAsmPrinter.swift
+++ b/Sources/Generator/ArmAsmPrinter.swift
@@ -13,101 +13,114 @@ public enum ArmAsmPrinter {
     }
 
     static func print(instruction: AsmRepresent.Instruction) -> String {
-        func inst(opecode: String, a: AsmRepresent.Register, b: AsmRepresent.Register) -> String {
+        /// opecode a, b
+        func inst(_ opecode: String, _ a: AsmRepresent.Register, _ b: AsmRepresent.Register) -> String {
             "    \(opecode) \(a.rawValue), \(b.rawValue)\n"
         }
 
-        func inst(opecode: String, a: AsmRepresent.Register, immediate: String) -> String {
+        /// opecode a, #immediate
+        func inst(_ opecode: String, _ a: AsmRepresent.Register, _ immediate: Int64) -> String {
             "    \(opecode) \(a.rawValue), #\(immediate)\n"
         }
 
-        func inst(opecode: String, a: AsmRepresent.Register, b: AsmRepresent.Register, c: AsmRepresent.Register) -> String {
+        /// opecode a, b, c
+        func inst(_ opecode: String, _ a: AsmRepresent.Register, _ b: AsmRepresent.Register, _ c: AsmRepresent.Register) -> String {
             "    \(opecode) \(a.rawValue), \(b.rawValue), \(c.rawValue)\n"
         }
 
-        func inst(opecode: String, a: AsmRepresent.Register, b: AsmRepresent.Register, immediate: String) -> String {
+        /// opecode a, b, #immediate
+        func inst(_ opecode: String, _ a: AsmRepresent.Register, _ b: AsmRepresent.Register, _ immediate: Int64) -> String {
             "    \(opecode) \(a.rawValue), \(b.rawValue), #\(immediate)\n"
         }
 
-        func inst(opecode: String, a: AsmRepresent.Register, address: AsmRepresent.Instruction.Address) -> String {
+        /// opecode a, [address]
+        func inst(_ opecode: String, _ a: AsmRepresent.Register, _ address: AsmRepresent.Instruction.Address) -> String {
             "    \(opecode) \(a.rawValue), [\(address.description)]\n"
         }
 
-        func inst(opecode: String, a: AsmRepresent.Register, b: AsmRepresent.Register, address: AsmRepresent.Instruction.Address) -> String {
+        /// opecode a, b, [address]
+        func inst(_ opecode: String, _ a: AsmRepresent.Register, _ b: AsmRepresent.Register, _ address: AsmRepresent.Instruction.Address) -> String {
             "    \(opecode) \(a.rawValue), \(b.rawValue), [\(address.description)]\n"
         }
 
-        func inst(opecode: String, label: String) -> String {
-            "    \(opecode) \(label)\n"
+        /// opecode label
+        func inst(_ opecode: String, _ label: String) -> String {
+            "    \(opecode) \(fixLabel(label))\n"
+        }
+
+        /// AppleClangではmainが_main じゃないとダメなので対応
+        func fixLabel(_ label: String) -> String {
+            label == "main" ? "_main" : label
         }
 
         return switch instruction {
         case .mov(let dst, let src): 
-            inst(opecode: "mov", a: dst, b: src)
+            inst("mov", dst, src)
         case .movi(let dst, let immediate): 
-            inst(opecode: "mov", a: dst, immediate: immediate.description)
+            inst("mov", dst, immediate)
         case .add(let dst, let src1, let src2): 
-            inst(opecode: "add", a: dst, b: src1, c: src2)
+            inst("add", dst, src1, src2)
         case .addi(let dst, let src, let immediate):
-            inst(opecode: "add", a: dst, b: src, immediate: immediate.description)
+            inst("add", dst, src, immediate)
         case .sub(let dst, let src1, let src2):
-            inst(opecode: "sub", a: dst, b: src1, c: src2)
+            inst("sub", dst, src1, src2)
         case .subi(let dst, let src, let immediate):
-            inst(opecode: "sub", a: dst, b: src, immediate: immediate.description)
+            inst("sub", dst, src, immediate)
         case .mul(let dst, let src1, let src2):
-            inst(opecode: "mul", a: dst, b: src1, c: src2)
+            inst("mul", dst, src1, src2)
         case .muli(let dst, let src, let immediate):
-            inst(opecode: "mul", a: dst, b: src, immediate: immediate.description)
+            inst("mul", dst, src, immediate)
         case .div(let dst, let src1, let src2):
-            inst(opecode: "sdiv", a: dst, b: src1, c: src2)
+            inst("sdiv", dst, src1, src2)
         case .divi(let dst, let src, let immediate):
-            inst(opecode: "sdiv", a: dst, b: src, immediate: immediate.description)
+            inst("sdiv", dst, src, immediate)
         case .push(let src):
-            "    str \(src.rawValue), [sp, #-16]!\n"
+            inst("sub", .sp, .sp, 16)
+            + inst("str", src, .register(.sp))
         case .pop(let dst):
-            inst(opecode: "ldr", a: dst, address: .register(.sp))
-            + inst(opecode: "add", a: .sp, b: .sp, immediate: "16")
+            inst("ldr", dst, .register(.sp))
+            + inst("add", .sp, .sp, 16)
         case .addr(let dst, let label):
             "    adrp \(dst.rawValue), \(label)@GOTPAGE\n"
             + "    ldr \(dst.rawValue), [\(dst.rawValue), \(label)@GOTPAGEOFF]\n"
         case .str(let src, let address):
-            inst(opecode: "str", a: src, address: address)
+            inst("str", src, address)
         case .strb(let src, let address):
-            inst(opecode: "strb", a: src, address: address)
+            inst("strb", src, address)
         case .stp(let src1, let src2, let address):
-            inst(opecode: "stp", a: src1, b: src2, address: address)
+            inst("stp", src1, src2, address)
         case .ldr(let dst, let address):
-            inst(opecode: "ldr", a: dst, address: address)
+            inst("ldr", dst, address)
         case .ldrb(let dst, let address):
-            inst(opecode: "ldrb", a: dst, address: address)
+            inst("ldrb", dst, address)
         case .ldp(let dst1, let dst2, let address):
-            inst(opecode: "ldp", a: dst1, b: dst2, address: address)
+            inst("ldp", dst1, dst2, address)
         case .cmp(let src1, let src2):
-            inst(opecode: "cmp", a: src1, b: src2)
+            inst("cmp", src1, src2)
         case .cmpi(let src, let immediate):
-            inst(opecode: "cmp", a: src, immediate: immediate.description)
+            inst("cmp", src, immediate)
         case .cset(let dst, let flag):
             "    cset \(dst.rawValue), \(flag.rawValue)\n"
         case .beq(let label):
-            inst(opecode: "beq", label: label == "main" ? "_main" : label)
+            inst("beq", label)
         case .b(let label):
-            inst(opecode: "b", label: label == "main" ? "_main" : label)
+            inst("b", label)
         case .bl(let label):
-            inst(opecode: "bl", label: label == "main" ? "_main" : label)
+            inst("bl", label)
         case .neg(let dst, let src):
-            inst(opecode: "neg", a: dst, b: src)
+            inst("neg", dst, src)
         case .lsli(let dst, let src, let immediate):
-            inst(opecode: "lsl", a: dst, b: src, immediate: immediate.description)
+            inst("lsl", dst, src, Int64(immediate))
         case .ret:
             "    ret\n"
         case .label(let label):
-            "\(label == "main" ? "_main" : label):\n"
+            "\(fixLabel(label)):\n"
         case .p2align(let factor):
             ".p2align \(factor)\n"
         case .section(let kinds):
             ".section \(kinds.map { $0.rawValue }.joined(separator: ","))\n"
         case .globl(let label):
-            ".globl \(label == "main" ? "_main" : label)\n"
+            ".globl \(fixLabel(label))\n"
         case .dataDecl(let kind, let value):
             "    .\(kind.rawValue) \(value)\n"
         }

--- a/Sources/Generator/AsmRepresentation.swift
+++ b/Sources/Generator/AsmRepresentation.swift
@@ -1,0 +1,123 @@
+
+public enum AsmRepresent {
+
+    public enum Instruction {
+        case mov(dst: Register, src: Register)
+        case movi(dst: Register, immediate: Int64)
+
+        case add(dst: Register, src1: Register, src2: Register)
+        case addi(dst: Register, src: Register, immediate: Int64)
+        case sub(dst: Register, src1: Register, src2: Register)
+        case subi(dst: Register, src: Register, immediate: Int64)
+        case mul(dst: Register, src1: Register, src2: Register)
+        case muli(dst: Register, src: Register, immediate: Int64)
+        case div(dst: Register, src1: Register, src2: Register)
+        case divi(dst: Register, src: Register, immediate: Int64)
+
+        case push(src: Register)
+        case pop(dst: Register)
+
+        /// dstにlabelのアドレスを入れる
+        case addr(dst: Register, label: String)
+
+        case str(src: Register, address: Address)
+        case strb(src: Register, address: Address)
+        case stp(src1: Register, src2: Register, address: Address)
+        case ldr(dst: Register, address: Address)
+        case ldrb(dst: Register, address: Address)
+        case ldp(dst1: Register, dst2: Register, address: Address)
+
+        case cmp(src1: Register, src2: Register)
+        case cmpi(src: Register, immediate: Int64)
+
+        case cset(dst: Register, flag: CsetFlag)
+
+        case beq(label: String)
+        case b(label: String)
+        case bl(label: String)
+
+        case neg(des: Register, src: Register)
+
+        case lsli(dst: Register, src: Register, immediate: UInt64)
+
+        case ret
+
+        // 実際には命令ではない、別のデータ構造で表すべき？
+        case label(label: String)
+        case p2align(factor: UInt64)
+        case section(kinds: [SectionKind])
+        case globl(label: String)
+        case dataDecl(kind: DataKind, value: String)
+
+        public enum Address {
+            case register(_ register: Register)
+            case distance(_ register: Register, _ diff: Int64)
+        }
+
+        public enum CsetFlag: String {
+            case eq
+            case ne
+            case lt
+            case le
+            case gt
+            case ge
+        }
+
+        public enum SectionKind: String {
+            case DATA = "__DATA"
+            case data = "__data"
+            case TEXT = "__TEXT"
+            case cstring = "__cstring"
+            case cstring_literals = "cstring_literals"
+        }
+
+        public enum DataKind: String {
+            case byte
+            case quad
+            case asciz
+            case comm
+        }
+    }
+
+    public enum Register: String {
+        case x0
+        case x1
+        case x2
+        case x3
+        case x4
+
+        case w0
+        case w1
+        case w2
+        case w3
+        case w4
+
+        case x29
+        case x30
+
+        case sp
+
+        static func x(_ index: Int) -> Register {
+            switch index {
+            case 0: .x0
+            case 1: .x1
+            case 2: .x2
+            case 3: .x3
+            case 4: .x4
+            default: fatalError()
+            }
+        }
+
+        static func w(_ index: Int) -> Register {
+            switch index {
+            case 0: .w0
+            case 1: .w1
+            case 2: .w2
+            case 3: .w3
+            case 4: .w4
+            default: fatalError()
+            }
+        }
+    }
+
+}

--- a/Tests/GeneratorTest/ArmAsmPrinterTest.swift
+++ b/Tests/GeneratorTest/ArmAsmPrinterTest.swift
@@ -1,0 +1,289 @@
+@testable import Generator
+import XCTest
+
+final class ArmAsmPrinterTest: XCTestCase {
+
+    func testMov() {
+        let result = ArmAsmPrinter.print(instruction: .mov(dst: .x0, src: .x1))
+        let expected = "    mov x0, x1\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testMovi() {
+        let result = ArmAsmPrinter.print(instruction: .movi(dst: .x0, immediate: 5))
+        let expected = "    mov x0, #5\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testAdd() {
+        let result = ArmAsmPrinter.print(instruction: .add(dst: .x0, src1: .x1, src2: .x2))
+        let expected = "    add x0, x1, x2\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testAddi() {
+        let result = ArmAsmPrinter.print(instruction: .addi(dst: .x0, src: .x1, immediate: 10))
+        let expected = "    add x0, x1, #10\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testSub() {
+        let result = ArmAsmPrinter.print(instruction: .sub(dst: .x0, src1: .x1, src2: .x2))
+        let expected = "    sub x0, x1, x2\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testSubi() {
+        let result = ArmAsmPrinter.print(instruction: .subi(dst: .x0, src: .x1, immediate: 10))
+        let expected = "    sub x0, x1, #10\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testMul() {
+        let result = ArmAsmPrinter.print(instruction: .mul(dst: .x0, src1: .x1, src2: .x2))
+        let expected = "    mul x0, x1, x2\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testMuli() {
+        let result = ArmAsmPrinter.print(instruction: .muli(dst: .x0, src: .x1, immediate: 10))
+        let expected = "    mul x0, x1, #10\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testDiv() {
+        let result = ArmAsmPrinter.print(instruction: .div(dst: .x0, src1: .x1, src2: .x2))
+        let expected = "    sdiv x0, x1, x2\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testDivi() {
+        let result = ArmAsmPrinter.print(instruction: .divi(dst: .x0, src: .x1, immediate: 10))
+        let expected = "    sdiv x0, x1, #10\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testPush() {
+        let result = ArmAsmPrinter.print(instruction: .push(src: .x0))
+        let expected = "    sub sp, sp, #16\n" + "    str x0, [sp]\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testPop() {
+        let result = ArmAsmPrinter.print(instruction: .pop(dst: .x0))
+        let expected = "    ldr x0, [sp]\n" + "    add sp, sp, #16\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testAddr() {
+        let result = ArmAsmPrinter.print(instruction: .addr(dst: .x0, label: "hoge"))
+        let expected = "    adrp x0, hoge@GOTPAGE\n"
+        + "    ldr x0, [x0, hoge@GOTPAGEOFF]\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testStr() {
+        let resultRegister = ArmAsmPrinter.print(instruction: .str(src: .x0, address: .register(.sp)))
+        let expectedRegister = "    str x0, [sp]\n"
+
+        XCTAssertEqual(resultRegister, expectedRegister)
+
+        let resultDistance = ArmAsmPrinter.print(instruction: .str(src: .x1, address: .distance(.sp, 8)))
+        let expectedDistance = "    str x1, [sp, #8]\n"
+        XCTAssertEqual(resultDistance, expectedDistance)
+    }
+
+    func testStrb() {
+        let resultRegister = ArmAsmPrinter.print(instruction: .strb(src: .x0, address: .register(.sp)))
+        let expectedRegister = "    strb x0, [sp]\n"
+
+        XCTAssertEqual(resultRegister, expectedRegister)
+
+        let resultDistance = ArmAsmPrinter.print(instruction: .strb(src: .x1, address: .distance(.sp, 8)))
+        let expectedDistance = "    strb x1, [sp, #8]\n"
+        XCTAssertEqual(resultDistance, expectedDistance)
+    }
+
+    func testStp() {
+        let resultRegister = ArmAsmPrinter.print(instruction: .stp(src1: .x29, src2: .x30, address: .register(.sp)))
+        let expectedRegister = "    stp x29, x30, [sp]\n"
+
+        XCTAssertEqual(resultRegister, expectedRegister)
+
+        let resultDistance = ArmAsmPrinter.print(instruction: .stp(src1: .x29, src2: .x30, address: .distance(.sp, 8)))
+        let expectedDistance = "    stp x29, x30, [sp, #8]\n"
+        XCTAssertEqual(resultDistance, expectedDistance)
+    }
+
+    func testLdr() {
+        let resultRegister = ArmAsmPrinter.print(instruction: .ldr(dst: .x0, address: .register(.sp)))
+        let expectedRegister = "    ldr x0, [sp]\n"
+
+        XCTAssertEqual(resultRegister, expectedRegister)
+
+        let resultDistance = ArmAsmPrinter.print(instruction: .ldr(dst: .x1, address: .distance(.sp, 8)))
+        let expectedDistance = "    ldr x1, [sp, #8]\n"
+        XCTAssertEqual(resultDistance, expectedDistance)
+    }
+
+    func testLdrb() {
+        let resultRegister = ArmAsmPrinter.print(instruction: .ldrb(dst: .x0, address: .register(.sp)))
+        let expectedRegister = "    ldrb x0, [sp]\n"
+
+        XCTAssertEqual(resultRegister, expectedRegister)
+
+        let resultDistance = ArmAsmPrinter.print(instruction: .ldrb(dst: .x1, address: .distance(.sp, 8)))
+        let expectedDistance = "    ldrb x1, [sp, #8]\n"
+        XCTAssertEqual(resultDistance, expectedDistance)
+    }
+
+    func testLdp() {
+        let resultRegister = ArmAsmPrinter.print(instruction: .ldp(dst1: .x29, dst2: .x30, address: .register(.sp)))
+        let expectedRegister = "    ldp x29, x30, [sp]\n"
+
+        XCTAssertEqual(resultRegister, expectedRegister)
+
+        let resultDistance = ArmAsmPrinter.print(instruction: .ldp(dst1: .x29, dst2: .x30, address: .distance(.sp, 8)))
+        let expectedDistance = "    ldp x29, x30, [sp, #8]\n"
+        XCTAssertEqual(resultDistance, expectedDistance)
+    }
+
+    func testCmp() {
+        let result = ArmAsmPrinter.print(instruction: .cmp(src1: .x0, src2: .x1))
+        let expected = "    cmp x0, x1\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testCmpi() {
+        let result = ArmAsmPrinter.print(instruction: .cmpi(src: .x0, immediate: 10))
+        let expected = "    cmp x0, #10\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testCset() {
+        let resultEq = ArmAsmPrinter.print(instruction: .cset(dst: .x0, flag: .eq))
+        let expectedEq = "    cset x0, eq\n"
+        XCTAssertEqual(resultEq, expectedEq)
+
+        let resultGe = ArmAsmPrinter.print(instruction: .cset(dst: .x0, flag: .ge))
+        let expectedGe = "    cset x0, ge\n"
+        XCTAssertEqual(resultGe, expectedGe)
+
+        let resultGt = ArmAsmPrinter.print(instruction: .cset(dst: .x0, flag: .gt))
+        let expectedGt = "    cset x0, gt\n"
+        XCTAssertEqual(resultGt, expectedGt)
+
+        let resultLe = ArmAsmPrinter.print(instruction: .cset(dst: .x0, flag: .le))
+        let expectedLe = "    cset x0, le\n"
+        XCTAssertEqual(resultLe, expectedLe)
+
+        let resultLt = ArmAsmPrinter.print(instruction: .cset(dst: .x0, flag: .lt))
+        let expectedLt = "    cset x0, lt\n"
+        XCTAssertEqual(resultLt, expectedLt)
+
+        let resultNe = ArmAsmPrinter.print(instruction: .cset(dst: .x0, flag: .ne))
+        let expectedNe = "    cset x0, ne\n"
+        XCTAssertEqual(resultNe, expectedNe)
+    }
+
+    func testBeq() {
+        let result = ArmAsmPrinter.print(instruction: .beq(label: "hoge"))
+        let expected = "    beq hoge\n"
+        XCTAssertEqual(result, expected)
+    }
+
+    func testB() {
+        let result = ArmAsmPrinter.print(instruction: .b(label: "hoge"))
+        let expected = "    b hoge\n"
+        XCTAssertEqual(result, expected)
+    }
+
+    func testBl() {
+        let result = ArmAsmPrinter.print(instruction: .bl(label: "hoge"))
+        let expected = "    bl hoge\n"
+        XCTAssertEqual(result, expected)
+    }
+
+    func testNeg() {
+        let result = ArmAsmPrinter.print(instruction: .neg(des: .x0, src: .x1))
+        let expected = "    neg x0, x1\n"
+        XCTAssertEqual(result, expected)
+    }
+
+    func testLsli() {
+        let result = ArmAsmPrinter.print(instruction: .lsli(dst: .x0, src: .x1, immediate: 3))
+        let expected = "    lsl x0, x1, #3\n"
+        XCTAssertEqual(result, expected)
+    }
+
+    func testRet() {
+        let result = ArmAsmPrinter.print(instruction: .ret)
+        let expected = "    ret\n"
+        XCTAssertEqual(result, expected)
+    }
+
+    func testLabel() {
+        let result = ArmAsmPrinter.print(instruction: .label(label: "hoge"))
+        let expected = "hoge:\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testP2align() {
+        let result = ArmAsmPrinter.print(instruction: .p2align(factor: 2))
+        let expected = ".p2align 2\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testSection() {
+        let result = ArmAsmPrinter.print(instruction: .section(kinds: [.DATA,.data,.cstring,.cstring_literals,.TEXT]))
+        let expected = ".section __DATA,__data,__cstring,cstring_literals,__TEXT\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testGlobl() {
+        let result = ArmAsmPrinter.print(instruction: .globl(label: "hoge"))
+        let expected = ".globl hoge\n"
+
+        XCTAssertEqual(result, expected)
+    }
+
+    func testDataDecl() {
+        let resultQuad = ArmAsmPrinter.print(instruction: .dataDecl(kind: .quad, value: "10"))
+        let expectedQuad = "    .quad 10\n"
+
+        XCTAssertEqual(resultQuad, expectedQuad)
+
+        let resultByte = ArmAsmPrinter.print(instruction: .dataDecl(kind: .byte, value: "10"))
+        let expectedByte = "    .byte 10\n"
+
+        XCTAssertEqual(resultByte, expectedByte)
+
+        let resultComm = ArmAsmPrinter.print(instruction: .dataDecl(kind: .comm, value: "a"))
+        let expectedComm = "    .comm a\n"
+
+        XCTAssertEqual(resultComm, expectedComm)
+
+        let resultAsciz = ArmAsmPrinter.print(instruction: .dataDecl(kind: .asciz, value: "\"aiueo\""))
+        let expectedAsciz = "    .asciz \"aiueo\"\n"
+
+        XCTAssertEqual(resultAsciz, expectedAsciz)
+    }
+}


### PR DESCRIPTION
# 概要
- 「アセンブリを文字列出力する機能」と「ASTを読んで解析する機能」を分離する
    - 関心の分離: llvmとかSILGenを見ると、代替`XXXPrinter`と`Gen`は別れている
    - （一応）これによってOptimizationやマルチプラットフォーム対応がしやすい構造になる

# 実装
- `Instruction`enumで命令を定義
    - 基本的に命令arm風だが、`push`, `pop`, `adr`などarmに存在しない命令もある
    - Dataセクションやラベルも定義
        - もしかしたら`DataSection`等の構造体を作った方が良いかもしれない
    - ある意味中間言語
- `ArmAsmPrinter`
    - `Instruction`を受け取って文字列を出力する
    - `X86_64AsmPrinter`などを作れば、マルチプラットフォーム対応できる想定